### PR TITLE
Fix P2S overheating issues, add issues tracker in the UI

### DIFF
--- a/.github/workflows/auto-update-index-json.yml
+++ b/.github/workflows/auto-update-index-json.yml
@@ -1,6 +1,7 @@
 name: Auto update index.json in PR
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 Official print presets for Polymaker 3D printing filaments, optimized for use with BambuStudio, OrcaSlicer, ElegooSlicer, and other compatible slicers.
 
+## ⚠️ Known Issues
+
+### P2S Overheating Issue (Temporary Fix)
+
+**Issue**: P2S printer overheating when printing materials with vitrification temperature > 50°C due to starting G-code issues.
+
+**Solution**: We have implemented a temporary fix by adding cooling G-code commands to the `filament_start_gcode` for all P2S presets with vitrification temperature > 50°C:
+
+```gcode
+M145 P0 ; set airduct mode to cooling mode for cooling
+M106 P2 S255 ; turn on auxiliary fan for cooling
+M106 P3 S127 ; turn on chamber fan for cooling
+M1002 gcode_claim_action : 29
+M191 S0 ; wait for chamber temp
+M106 P2 S102 ; turn on chamber cooling fan
+M106 P10 S0 ; turn off left aux fan
+M142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling
+```
+
+This is a temporary workaround. We will remove this change after Bambu Lab fixes this issue.
+
+**Acknowledgements**: Thanks to alexbreinig for pointing out this issue and capsel22 for reporting it in the BambuStudio issues. For more details, see: https://github.com/bambulab/BambuStudio/issues/8801
+
 ## 🌐 Download Presets
 
 **Visit our download page:** [https://presets.polymaker.com](https://presets.polymaker.com) 

--- a/app.js
+++ b/app.js
@@ -849,6 +849,30 @@ function initModal() {
   });
 }
 
+// Accordion functionality for Known Issues
+function initAccordion() {
+  var accordionHeaders = document.querySelectorAll('.accordion-header');
+
+  accordionHeaders.forEach(function (header) {
+    header.addEventListener('click', function () {
+      var item = header.parentElement;
+      var isCollapsed = item.classList.contains('is-collapsed');
+      var icon = header.querySelector('.accordion-icon');
+
+      if (isCollapsed) {
+        item.classList.remove('is-collapsed');
+        header.setAttribute('aria-expanded', 'true');
+        icon.textContent = '▼';
+      } else {
+        item.classList.add('is-collapsed');
+        header.setAttribute('aria-expanded', 'false');
+        icon.textContent = '▼';
+      }
+    });
+  });
+}
+
 // Tooltip positioning to prevent clipping
 init();
 initModal();
+initAccordion();

--- a/index.html
+++ b/index.html
@@ -33,21 +33,6 @@
       <p class="hero-desc">Select your slicer to view and download Polymaker preset files</p>
     </header>
 
-    <section class="card warning-card" id="warning-card">
-      <div class="warning-header">
-        <span class="warning-icon">⚠️</span>
-        <h2 class="warning-title">P2S Overheating Issue - Temporary Fix Applied</h2>
-      </div>
-      <div class="warning-content">
-        <p><strong>Issue:</strong> P2S printer may overheat when printing materials with vitrification temperature > 50°C due to starting G-code issues.</p>
-        <p><strong>Solution:</strong> We have implemented a temporary fix by adding cooling G-code commands to P2S presets with vitrification temperature > 50°C. This is a temporary workaround until Bambu Lab fixes this issue.</p>
-        <p class="warning-links">
-          <a href="https://github.com/bambulab/BambuStudio/issues/8801" target="_blank" rel="noopener noreferrer">View BambuStudio Issue #8801 →</a>
-        </p>
-        <p class="warning-credits">Thanks to alexbreinig and capsel22 for identifying this issue.</p>
-      </div>
-    </section>
-
     <section class="card slicer-card" id="slicer-card">
       <div class="slicer-filter">
         <div class="filter-group slicer-filter-group">
@@ -171,8 +156,31 @@
           </div>
         </div>
       </div>
-      <p class="footer-readme">For more information, see <a href="https://github.com/Polymaker3D/Polymaker-Preset#readme" target="_blank" rel="noopener noreferrer">README</a></p>
     </footer>
+
+    <section class="known-issues-section">
+      <h2 class="known-issues-title">Known Issues</h2>
+      <div class="accordion">
+        <div class="accordion-item is-collapsed">
+          <button class="accordion-header" type="button" aria-expanded="false">
+            <span class="accordion-title">P2S Overheating Issue - Temporary Fix Applied</span>
+            <span class="accordion-icon" aria-hidden="true">▼</span>
+          </button>
+          <div class="accordion-content">
+            <div class="accordion-body">
+              <p><strong>Issue:</strong> P2S printer may overheat when printing materials with vitrification temperature &gt; 50°C due to starting G-code issues.</p>
+              <p><strong>Solution:</strong> We have implemented a temporary fix by adding cooling G-code commands to P2S presets with vitrification temperature &gt; 50°C. This is a temporary workaround until Bambu Lab fixes this issue.</p>
+              <p class="accordion-links">
+                <a href="https://github.com/bambulab/BambuStudio/issues/8801" target="_blank" rel="noopener noreferrer">View BambuStudio Issue #8801 →</a>
+              </p>
+              <p class="accordion-credits">Thanks to alexbreinig and capsel22 for identifying this issue.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <p class="footer-readme">For more information, see <a href="https://github.com/Polymaker3D/Polymaker-Preset#readme" target="_blank" rel="noopener noreferrer">README</a></p>
   </div>
 
   <!-- Manual Installation Modal -->

--- a/index.html
+++ b/index.html
@@ -119,6 +119,28 @@
       </div>
     </section>
 
+    <section class="known-issues-section">
+      <h2 class="known-issues-title">Known Issues</h2>
+      <div class="accordion">
+        <div class="accordion-item is-collapsed">
+          <button class="accordion-header" type="button" aria-expanded="false">
+            <span class="accordion-title">P2S Overheating Issue - Temporary Fix Applied</span>
+            <span class="accordion-icon" aria-hidden="true">▼</span>
+          </button>
+          <div class="accordion-content">
+            <div class="accordion-body">
+              <p><strong>Issue:</strong> P2S printer may overheat when printing materials with vitrification temperature &gt; 50°C due to starting G-code issues.</p>
+              <p><strong>Solution:</strong> We have implemented a temporary fix by adding cooling G-code commands to P2S presets with vitrification temperature &gt; 50°C. This is a temporary workaround until Bambu Lab fixes this issue.</p>
+              <p class="accordion-links">
+                <a href="https://github.com/bambulab/BambuStudio/issues/8801" target="_blank" rel="noopener noreferrer">View BambuStudio Issue #8801 →</a>
+              </p>
+              <p class="accordion-credits">Thanks to alexbreinig and capsel22 for identifying this issue.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <footer class="footer">
       <div class="footer-columns">
         <div class="footer-col footer-col-links">
@@ -156,31 +178,8 @@
           </div>
         </div>
       </div>
+      <p class="footer-readme">For more information, see <a href="https://github.com/Polymaker3D/Polymaker-Preset#readme" target="_blank" rel="noopener noreferrer">README</a></p>
     </footer>
-
-    <section class="known-issues-section">
-      <h2 class="known-issues-title">Known Issues</h2>
-      <div class="accordion">
-        <div class="accordion-item is-collapsed">
-          <button class="accordion-header" type="button" aria-expanded="false">
-            <span class="accordion-title">P2S Overheating Issue - Temporary Fix Applied</span>
-            <span class="accordion-icon" aria-hidden="true">▼</span>
-          </button>
-          <div class="accordion-content">
-            <div class="accordion-body">
-              <p><strong>Issue:</strong> P2S printer may overheat when printing materials with vitrification temperature &gt; 50°C due to starting G-code issues.</p>
-              <p><strong>Solution:</strong> We have implemented a temporary fix by adding cooling G-code commands to P2S presets with vitrification temperature &gt; 50°C. This is a temporary workaround until Bambu Lab fixes this issue.</p>
-              <p class="accordion-links">
-                <a href="https://github.com/bambulab/BambuStudio/issues/8801" target="_blank" rel="noopener noreferrer">View BambuStudio Issue #8801 →</a>
-              </p>
-              <p class="accordion-credits">Thanks to alexbreinig and capsel22 for identifying this issue.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <p class="footer-readme">For more information, see <a href="https://github.com/Polymaker3D/Polymaker-Preset#readme" target="_blank" rel="noopener noreferrer">README</a></p>
   </div>
 
   <!-- Manual Installation Modal -->

--- a/index.html
+++ b/index.html
@@ -33,6 +33,21 @@
       <p class="hero-desc">Select your slicer to view and download Polymaker preset files</p>
     </header>
 
+    <section class="card warning-card" id="warning-card">
+      <div class="warning-header">
+        <span class="warning-icon">⚠️</span>
+        <h2 class="warning-title">P2S Overheating Issue - Temporary Fix Applied</h2>
+      </div>
+      <div class="warning-content">
+        <p><strong>Issue:</strong> P2S printer may overheat when printing materials with vitrification temperature > 50°C due to starting G-code issues.</p>
+        <p><strong>Solution:</strong> We have implemented a temporary fix by adding cooling G-code commands to P2S presets with vitrification temperature > 50°C. This is a temporary workaround until Bambu Lab fixes this issue.</p>
+        <p class="warning-links">
+          <a href="https://github.com/bambulab/BambuStudio/issues/8801" target="_blank" rel="noopener noreferrer">View BambuStudio Issue #8801 →</a>
+        </p>
+        <p class="warning-credits">Thanks to alexbreinig and capsel22 for identifying this issue.</p>
+      </div>
+    </section>
+
     <section class="card slicer-card" id="slicer-card">
       <div class="slicer-filter">
         <div class="filter-group slicer-filter-group">

--- a/preset/Panchroma CoPE/BBL/P2S/BambuStudio/Panchroma CoPE @BBL P2S.json
+++ b/preset/Panchroma CoPE/BBL/P2S/BambuStudio/Panchroma CoPE @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Celestial/BBL/P2S/BambuStudio/Panchroma PLA Celestial @BBL P2S.json
+++ b/preset/Panchroma PLA Celestial/BBL/P2S/BambuStudio/Panchroma PLA Celestial @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Galaxy/BBL/P2S/BambuStudio/Panchroma PLA Galaxy @BBL P2S.json
+++ b/preset/Panchroma PLA Galaxy/BBL/P2S/BambuStudio/Panchroma PLA Galaxy @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Glow/BBL/P2S/BambuStudio/Panchroma PLA Glow @BBL P2S.json
+++ b/preset/Panchroma PLA Glow/BBL/P2S/BambuStudio/Panchroma PLA Glow @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Luminous/BBL/P2S/BambuStudio/Panchroma PLA Luminous @BBL P2S.json
+++ b/preset/Panchroma PLA Luminous/BBL/P2S/BambuStudio/Panchroma PLA Luminous @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Marble/BBL/P2S/BambuStudio/Panchroma PLA Marble @BBL P2S.json
+++ b/preset/Panchroma PLA Marble/BBL/P2S/BambuStudio/Panchroma PLA Marble @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Matte/BBL/P2S/BambuStudio/Panchroma PLA Matte @BBL P2S.json
+++ b/preset/Panchroma PLA Matte/BBL/P2S/BambuStudio/Panchroma PLA Matte @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Metallic/BBL/P2S/BambuStudio/Panchroma PLA Metallic @BBL P2S.json
+++ b/preset/Panchroma PLA Metallic/BBL/P2S/BambuStudio/Panchroma PLA Metallic @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Neon/BBL/P2S/BambuStudio/Panchroma PLA Neon @BBL P2S.json
+++ b/preset/Panchroma PLA Neon/BBL/P2S/BambuStudio/Panchroma PLA Neon @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Satin/BBL/P2S/BambuStudio/Panchroma PLA Satin @BBL P2S.json
+++ b/preset/Panchroma PLA Satin/BBL/P2S/BambuStudio/Panchroma PLA Satin @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Silk/BBL/P2S/BambuStudio/Panchroma PLA Silk @BBL P2S.json
+++ b/preset/Panchroma PLA Silk/BBL/P2S/BambuStudio/Panchroma PLA Silk @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Starlight/BBL/P2S/BambuStudio/Panchroma PLA Starlight @BBL P2S.json
+++ b/preset/Panchroma PLA Starlight/BBL/P2S/BambuStudio/Panchroma PLA Starlight @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA Translucent/BBL/P2S/BambuStudio/Panchroma PLA Translucent @BBL P2S.json
+++ b/preset/Panchroma PLA Translucent/BBL/P2S/BambuStudio/Panchroma PLA Translucent @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA UV Shift/BBL/P2S/BambuStudio/Panchroma PLA UV Shift @BBL P2S.json
+++ b/preset/Panchroma PLA UV Shift/BBL/P2S/BambuStudio/Panchroma PLA UV Shift @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Panchroma PLA/BBL/P2S/BambuStudio/Panchroma PLA @BBL P2S.json
+++ b/preset/Panchroma PLA/BBL/P2S/BambuStudio/Panchroma PLA @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyLite CosPLA/BBL/P2S/BambuStudio/PolyLite CosPLA @BBL P2S.json
+++ b/preset/PolyLite CosPLA/BBL/P2S/BambuStudio/PolyLite CosPLA @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyLite PLA Galaxy/BBL/P2S/BambuStudio/PolyLite PLA Galaxy @BBL P2S.json
+++ b/preset/PolyLite PLA Galaxy/BBL/P2S/BambuStudio/PolyLite PLA Galaxy @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyLite PLA Glow/BBL/P2S/BambuStudio/PolyLite PLA Glow @BBL P2S.json
+++ b/preset/PolyLite PLA Glow/BBL/P2S/BambuStudio/PolyLite PLA Glow @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyLite PLA Luminous/BBL/P2S/BambuStudio/PolyLite PLA Luminous @BBL P2S.json
+++ b/preset/PolyLite PLA Luminous/BBL/P2S/BambuStudio/PolyLite PLA Luminous @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyLite PLA Neon/BBL/P2S/BambuStudio/PolyLite PLA Neon @BBL P2S.json
+++ b/preset/PolyLite PLA Neon/BBL/P2S/BambuStudio/PolyLite PLA Neon @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyLite PLA Pro Metallic/BBL/P2S/BambuStudio/PolyLite PLA Pro Metallic @BBL P2S.json
+++ b/preset/PolyLite PLA Pro Metallic/BBL/P2S/BambuStudio/PolyLite PLA Pro Metallic @BBL P2S.json
@@ -232,7 +232,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_tower_interface_pre_extrusion_dist": [
         "10"

--- a/preset/PolyLite PLA Pro/BBL/P2S/BambuStudio/PolyLite PLA Pro @BBL P2S.json
+++ b/preset/PolyLite PLA Pro/BBL/P2S/BambuStudio/PolyLite PLA Pro @BBL P2S.json
@@ -232,7 +232,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_tower_interface_pre_extrusion_dist": [
         "10"

--- a/preset/PolyLite PLA Starlight/BBL/P2S/BambuStudio/PolyLite PLA Starlight @BBL P2S.json
+++ b/preset/PolyLite PLA Starlight/BBL/P2S/BambuStudio/PolyLite PLA Starlight @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyLite PLA Translucent/BBL/P2S/BambuStudio/PolyLite PLA Translucent @BBL P2S.json
+++ b/preset/PolyLite PLA Translucent/BBL/P2S/BambuStudio/PolyLite PLA Translucent @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyLite PLA/BBL/P2S/BambuStudio/PolyLite PLA @BBL P2S.json
+++ b/preset/PolyLite PLA/BBL/P2S/BambuStudio/PolyLite PLA @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyTerra PLA Marble/BBL/P2S/BambuStudio/PolyTerra PLA Marble @BBL P2S.json
+++ b/preset/PolyTerra PLA Marble/BBL/P2S/BambuStudio/PolyTerra PLA Marble @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyTerra PLA+/BBL/P2S/BambuStudio/PolyTerra PLA+ @BBL P2S.json
+++ b/preset/PolyTerra PLA+/BBL/P2S/BambuStudio/PolyTerra PLA+ @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/PolyTerra PLA/BBL/P2S/BambuStudio/PolyTerra PLA @BBL P2S.json
+++ b/preset/PolyTerra PLA/BBL/P2S/BambuStudio/PolyTerra PLA @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Polymaker HT-PLA-GF/BBL/P2S/BambuStudio/Polymaker HT-PLA-GF @BBL P2S.json
+++ b/preset/Polymaker HT-PLA-GF/BBL/P2S/BambuStudio/Polymaker HT-PLA-GF @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Polymaker HT-PLA/BBL/P2S/BambuStudio/Polymaker HT-PLA @BBL P2S.json
+++ b/preset/Polymaker HT-PLA/BBL/P2S/BambuStudio/Polymaker HT-PLA @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Polymaker PLA Pro Metallic/BBL/P2S/BambuStudio/Polymaker PLA Pro Metallic @BBL P2S.json
+++ b/preset/Polymaker PLA Pro Metallic/BBL/P2S/BambuStudio/Polymaker PLA Pro Metallic @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Polymaker PLA Pro/BBL/P2S/BambuStudio/Polymaker PLA Pro @BBL P2S.json
+++ b/preset/Polymaker PLA Pro/BBL/P2S/BambuStudio/Polymaker PLA Pro @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/preset/Polymaker PLA/BBL/P2S/BambuStudio/Polymaker PLA @BBL P2S.json
+++ b/preset/Polymaker PLA/BBL/P2S/BambuStudio/Polymaker PLA @BBL P2S.json
@@ -181,7 +181,7 @@
         "0"
     ],
     "filament_start_gcode": [
-        "; Filament gcode\n"
+        "; Filament gcode\nM145 P0 ; set airduct mode to cooling mode for cooling\nM106 P2 S255 ; turn on auxiliary fan for cooling\nM106 P3 S127 ; turn on chamber fan for cooling\nM1002 gcode_claim_action : 29\nM191 S0 ; wait for chamber temp\nM106 P2 S102 ; turn on chamber cooling fan\nM106 P10 S0 ; turn off left aux fan\nM142 P6 R30 S40 U0.3 V0.8 ; set PETG exhaust chamber autocooling\n"
     ],
     "filament_type": [
         "PLA"

--- a/style.css
+++ b/style.css
@@ -984,6 +984,7 @@ body.theme-wiki .btn-download-selected:disabled {
   font-size: 0.7rem;
   color: var(--text-muted);
   flex-shrink: 0;
+  border-top: 1px solid var(--border);
 }
 
 .footer-columns {
@@ -1091,10 +1092,12 @@ body.theme-wiki .btn-download-selected:disabled {
 }
 
 .footer-readme {
-  margin: 0.5rem 0 0;
-  padding-top: 0.75rem;
+  margin: 0;
+  padding: 0.75rem 0;
   border-top: 1px solid var(--border);
   text-align: center;
+  font-size: 0.7rem;
+  color: var(--text-muted);
 }
 
 body.theme-wiki .footer-label {
@@ -1428,4 +1431,136 @@ body.theme-wiki .install-steps strong {
     padding-left: 1.1rem;
     font-size: 0.85rem;
   }
+}
+
+/* Known Issues Section */
+.known-issues-section {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  backdrop-filter: blur(10px);
+}
+
+.known-issues-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 0.75rem 0;
+}
+
+/* Accordion */
+.accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.accordion-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition: border-color var(--transition);
+}
+
+.accordion-item:hover {
+  border-color: rgba(234, 179, 8, 0.4);
+}
+
+body.theme-wiki .accordion-item:hover {
+  border-color: rgba(234, 179, 8, 0.3);
+}
+
+.accordion-header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 0.75rem;
+  background: rgba(234, 179, 8, 0.06);
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text);
+  text-align: left;
+  transition: background-color var(--transition);
+}
+
+.accordion-header:hover {
+  background: rgba(234, 179, 8, 0.1);
+}
+
+body.theme-wiki .accordion-header {
+  background: rgba(234, 179, 8, 0.08);
+}
+
+body.theme-wiki .accordion-header:hover {
+  background: rgba(234, 179, 8, 0.12);
+}
+
+.accordion-title {
+  flex: 1;
+}
+
+.accordion-icon {
+  font-size: 0.75rem;
+  transition: transform 0.2s ease;
+  margin-left: 0.5rem;
+}
+
+.accordion-item.is-collapsed .accordion-icon {
+  transform: rotate(-90deg);
+}
+
+.accordion-content {
+  max-height: 500px;
+  overflow: hidden;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+}
+
+.accordion-item.is-collapsed .accordion-content {
+  max-height: 0;
+}
+
+.accordion-body {
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.accordion-item.is-collapsed .accordion-body {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.accordion-body p {
+  margin: 0 0 0.5rem 0;
+}
+
+.accordion-body p:last-child {
+  margin-bottom: 0;
+}
+
+.accordion-links {
+  margin-top: 0.5rem;
+}
+
+.accordion-links a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.accordion-links a:hover {
+  text-decoration: underline;
+}
+
+.accordion-credits {
+  font-size: 0.75rem;
+  font-style: italic;
+  opacity: 0.8;
 }

--- a/style.css
+++ b/style.css
@@ -261,6 +261,78 @@ body.theme-wiki .theme-toggle-btn:hover {
   border-color: rgba(80, 191, 202, 0.5);
 }
 
+/* Warning card */
+.warning-card {
+  padding: 0.75rem 1rem;
+  border-color: rgba(234, 179, 8, 0.4);
+  background: rgba(234, 179, 8, 0.08);
+}
+
+.warning-card:hover {
+  border-color: rgba(234, 179, 8, 0.6);
+}
+
+body.theme-wiki .warning-card {
+  background: rgba(234, 179, 8, 0.12);
+  border-color: rgba(234, 179, 8, 0.3);
+}
+
+.warning-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.warning-icon {
+  font-size: 1.25rem;
+}
+
+.warning-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #eab308;
+  margin: 0;
+}
+
+body.theme-wiki .warning-title {
+  color: #a16207;
+}
+
+.warning-content {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.warning-content p {
+  margin: 0 0 0.5rem 0;
+}
+
+.warning-content p:last-child {
+  margin-bottom: 0;
+}
+
+.warning-links {
+  margin-top: 0.5rem;
+}
+
+.warning-links a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.warning-links a:hover {
+  text-decoration: underline;
+}
+
+.warning-credits {
+  font-size: 0.75rem;
+  font-style: italic;
+  opacity: 0.8;
+}
+
 .slicer-filter {
   display: flex;
   justify-content: flex-start;


### PR DESCRIPTION
# Summary:
- Fix P2S printer overheating issue - Resolves overheating problems when printing materials with vitrification temperature > 50°C on Bambu Lab P2S printers.

# Problem:
- P2S printers experience overheating during prints due to starting G-code issues (BambuStudio #8801). This affects all materials with vitrification temperature > 50°C.

# Solution:
- Added cooling G-code commands to "filament_start_gcode" for all 33 affected P2S presets

# Additional Changes:
- Added warning notices to README.md and download page (index.html) with link to upstream issue
- Added collapsible "Known Issues" section to the UI
- Minor HTML element fixes
- CI workflow now supports manual triggering via workflow_dispatch
# References:
- Fixes: https://github.com/bambulab/BambuStudio/issues/8801
- Thanks to alexbreinig and capsel22 for identifying this issue