### PR TITLE
Updated Prusa Core One profiles : removed HF nozzle exclusion

### DIFF
--- a/preset/Panchroma CoPE/Prusa/Core One/PrusaSlicer/Panchroma CoPE @Prusa Core One.ini
+++ b/preset/Panchroma CoPE/Prusa/Core One/PrusaSlicer/Panchroma CoPE @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Celestial/Prusa/Core One/PrusaSlicer/Panchroma PLA Celestial @Prusa Core One.ini
+++ b/preset/Panchroma PLA Celestial/Prusa/Core One/PrusaSlicer/Panchroma PLA Celestial @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Galaxy/Prusa/Core One/PrusaSlicer/Panchroma PLA Galaxy @Prusa Core One.ini
+++ b/preset/Panchroma PLA Galaxy/Prusa/Core One/PrusaSlicer/Panchroma PLA Galaxy @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Glow/Prusa/Core One/PrusaSlicer/Panchroma PLA Glow @Prusa Core One.ini
+++ b/preset/Panchroma PLA Glow/Prusa/Core One/PrusaSlicer/Panchroma PLA Glow @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Luminous/Prusa/Core One/PrusaSlicer/Panchroma PLA Luminous @Prusa Core One.ini
+++ b/preset/Panchroma PLA Luminous/Prusa/Core One/PrusaSlicer/Panchroma PLA Luminous @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Marble/Prusa/Core One/PrusaSlicer/Panchroma PLA Marble @Prusa Core One.ini
+++ b/preset/Panchroma PLA Marble/Prusa/Core One/PrusaSlicer/Panchroma PLA Marble @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Matte/Prusa/Core One/PrusaSlicer/Panchroma PLA Matte @Prusa Core One.ini
+++ b/preset/Panchroma PLA Matte/Prusa/Core One/PrusaSlicer/Panchroma PLA Matte @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Metallic/Prusa/Core One/PrusaSlicer/Panchroma PLA Metallic @Prusa Core One.ini
+++ b/preset/Panchroma PLA Metallic/Prusa/Core One/PrusaSlicer/Panchroma PLA Metallic @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Neon/Prusa/Core One/PrusaSlicer/Panchroma PLA Neon @Prusa Core One.ini
+++ b/preset/Panchroma PLA Neon/Prusa/Core One/PrusaSlicer/Panchroma PLA Neon @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Satin/Prusa/Core One/PrusaSlicer/Panchroma PLA Satin @Prusa Core One.ini
+++ b/preset/Panchroma PLA Satin/Prusa/Core One/PrusaSlicer/Panchroma PLA Satin @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Silk/Prusa/Core One/PrusaSlicer/Panchroma PLA Silk @Prusa Core One.ini
+++ b/preset/Panchroma PLA Silk/Prusa/Core One/PrusaSlicer/Panchroma PLA Silk @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Starlight/Prusa/Core One/PrusaSlicer/Panchroma PLA Starlight @Prusa Core One.ini
+++ b/preset/Panchroma PLA Starlight/Prusa/Core One/PrusaSlicer/Panchroma PLA Starlight @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA Translucent/Prusa/Core One/PrusaSlicer/Panchroma PLA Translucent @Prusa Core One.ini
+++ b/preset/Panchroma PLA Translucent/Prusa/Core One/PrusaSlicer/Panchroma PLA Translucent @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA UV Shift/Prusa/Core One/PrusaSlicer/Panchroma PLA UV Shift @Prusa Core One.ini
+++ b/preset/Panchroma PLA UV Shift/Prusa/Core One/PrusaSlicer/Panchroma PLA UV Shift @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Panchroma PLA/Prusa/Core One/PrusaSlicer/Panchroma PLA @Prusa Core One.ini
+++ b/preset/Panchroma PLA/Prusa/Core One/PrusaSlicer/Panchroma PLA @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite CosPLA/Prusa/Core One/PrusaSlicer/PolyLite CosPLA @Prusa Core One.ini
+++ b/preset/PolyLite CosPLA/Prusa/Core One/PrusaSlicer/PolyLite CosPLA @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite PLA Galaxy/Prusa/Core One/PrusaSlicer/PolyLite PLA Galaxy @Prusa Core One.ini
+++ b/preset/PolyLite PLA Galaxy/Prusa/Core One/PrusaSlicer/PolyLite PLA Galaxy @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite PLA Glow/Prusa/Core One/PrusaSlicer/PolyLite PLA Glow @Prusa Core One.ini
+++ b/preset/PolyLite PLA Glow/Prusa/Core One/PrusaSlicer/PolyLite PLA Glow @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite PLA Luminous/Prusa/Core One/PrusaSlicer/PolyLite PLA Luminous @Prusa Core One.ini
+++ b/preset/PolyLite PLA Luminous/Prusa/Core One/PrusaSlicer/PolyLite PLA Luminous @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite PLA Neon/Prusa/Core One/PrusaSlicer/PolyLite PLA Neon @Prusa Core One.ini
+++ b/preset/PolyLite PLA Neon/Prusa/Core One/PrusaSlicer/PolyLite PLA Neon @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite PLA Pro Metallic/Prusa/Core One/PrusaSlicer/PolyLite PLA Pro Metallic @Prusa Core One.ini
+++ b/preset/PolyLite PLA Pro Metallic/Prusa/Core One/PrusaSlicer/PolyLite PLA Pro Metallic @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite PLA Pro/Prusa/Core One/PrusaSlicer/PolyLite PLA Pro @Prusa Core One.ini
+++ b/preset/PolyLite PLA Pro/Prusa/Core One/PrusaSlicer/PolyLite PLA Pro @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite PLA Starlight/Prusa/Core One/PrusaSlicer/PolyLite PLA Starlight @Prusa Core One.ini
+++ b/preset/PolyLite PLA Starlight/Prusa/Core One/PrusaSlicer/PolyLite PLA Starlight @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite PLA Translucent/Prusa/Core One/PrusaSlicer/PolyLite PLA Translucent @Prusa Core One.ini
+++ b/preset/PolyLite PLA Translucent/Prusa/Core One/PrusaSlicer/PolyLite PLA Translucent @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyLite PLA/Prusa/Core One/PrusaSlicer/PolyLite PLA @Prusa Core One.ini
+++ b/preset/PolyLite PLA/Prusa/Core One/PrusaSlicer/PolyLite PLA @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyMax PLA/Prusa/Core One/PrusaSlicer/PolyMax PLA @Prusa Core One.ini
+++ b/preset/PolyMax PLA/Prusa/Core One/PrusaSlicer/PolyMax PLA @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyTerra PLA Marble/Prusa/Core One/PrusaSlicer/PolyTerra PLA Marble @Prusa Core One.ini
+++ b/preset/PolyTerra PLA Marble/Prusa/Core One/PrusaSlicer/PolyTerra PLA Marble @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyTerra PLA+/Prusa/Core One/PrusaSlicer/PolyTerra PLA+ @Prusa Core One.ini
+++ b/preset/PolyTerra PLA+/Prusa/Core One/PrusaSlicer/PolyTerra PLA+ @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/PolyTerra PLA/Prusa/Core One/PrusaSlicer/PolyTerra PLA @Prusa Core One.ini
+++ b/preset/PolyTerra PLA/Prusa/Core One/PrusaSlicer/PolyTerra PLA @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 0
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Polymaker HT-PLA-GF/Prusa/Core One/PrusaSlicer/Polymaker HT-PLA-GF @Prusa Core One.ini
+++ b/preset/Polymaker HT-PLA-GF/Prusa/Core One/PrusaSlicer/Polymaker HT-PLA-GF @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Polymaker HT-PLA/Prusa/Core One/PrusaSlicer/Polymaker HT-PLA @Prusa Core One.ini
+++ b/preset/Polymaker HT-PLA/Prusa/Core One/PrusaSlicer/Polymaker HT-PLA @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Polymaker PETG Galaxy/Prusa/Core One/PrusaSlicer/Polymaker PETG Galaxy @Prusa Core One.ini
+++ b/preset/Polymaker PETG Galaxy/Prusa/Core One/PrusaSlicer/Polymaker PETG Galaxy @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 80
 chamber_minimal_temperature = 0
 chamber_temperature = 35
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.6 and nozzle_diameter[0]!=0.8 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Polymaker PETG/Prusa/Core One/PrusaSlicer/Polymaker PETG @Prusa Core One.ini
+++ b/preset/Polymaker PETG/Prusa/Core One/PrusaSlicer/Polymaker PETG @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 80
 chamber_minimal_temperature = 0
 chamber_temperature = 35
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.6 and nozzle_diameter[0]!=0.8 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Polymaker PLA Pro Metallic/Prusa/Core One/PrusaSlicer/Polymaker PLA Pro Metallic @Prusa Core One.ini
+++ b/preset/Polymaker PLA Pro Metallic/Prusa/Core One/PrusaSlicer/Polymaker PLA Pro Metallic @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Polymaker PLA Pro/Prusa/Core One/PrusaSlicer/Polymaker PLA Pro @Prusa Core One.ini
+++ b/preset/Polymaker PLA Pro/Prusa/Core One/PrusaSlicer/Polymaker PLA Pro @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1

--- a/preset/Polymaker PLA/Prusa/Core One/PrusaSlicer/Polymaker PLA @Prusa Core One.ini
+++ b/preset/Polymaker PLA/Prusa/Core One/PrusaSlicer/Polymaker PLA @Prusa Core One.ini
@@ -4,7 +4,7 @@ bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
 compatible_printers = 
-compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6 and ! nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(COREONE|COREONEMMU3|COREONEL|COREONELMMU3)/ and nozzle_diameter[0]==0.4
 compatible_prints = 
 compatible_prints_condition = 
 cooling = 1


### PR DESCRIPTION
Updated all Prusa Core One profiles to remove '! nozzle_high_flow[0]' from 'compatible_printers_condition' so that the profiles are compatible with the default printer configuration which ships with a CHT nozzle.

Also replaced 'nozzle_diameter[0]!=0.8 and nozzle_diameter[0]!=0.6' by 'nozzle_diameter[0]==0.4' as the intent is clearer.

Fixes #32 