### PR TITLE
Update material presets and expand printer compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
   "@type": "ItemList",
   "name": "Polymaker filament presets",
   "description": "Official Polymaker 3D printing filament presets by material, printer, and slicer for Bambu Studio, OrcaSlicer, ElegooSlicer, and PrusaSlicer.",
-  "numberOfItems": 689,
+  "numberOfItems": 695,
   "itemListElement": [
     {
       "@type": "ListItem",
@@ -4924,12 +4924,12 @@
       "position": 349,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker PolyFlex TPU95 filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "PolyFlex TPU95-HF",
+        "category": "PolyFlex TPU95",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4938,7 +4938,7 @@
       "position": 350,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4952,7 +4952,7 @@
       "position": 351,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4966,12 +4966,12 @@
       "position": 352,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite ABS filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "PolyLite ABS",
+        "category": "PolyFlex TPU95-HF",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4980,7 +4980,7 @@
       "position": 353,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite ABS filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker PolyLite ABS filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4994,12 +4994,12 @@
       "position": 354,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker PolyLite ABS filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "PolyLite CosPLA",
+        "category": "PolyLite ABS",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -5008,7 +5008,7 @@
       "position": 355,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5022,7 +5022,7 @@
       "position": 356,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5036,7 +5036,7 @@
       "position": 357,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5050,7 +5050,7 @@
       "position": 358,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5064,7 +5064,7 @@
       "position": 359,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5078,7 +5078,7 @@
       "position": 360,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5092,7 +5092,7 @@
       "position": 361,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5106,7 +5106,7 @@
       "position": 362,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5120,7 +5120,7 @@
       "position": 363,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5134,7 +5134,7 @@
       "position": 364,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5148,7 +5148,7 @@
       "position": 365,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5162,7 +5162,7 @@
       "position": 366,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5176,7 +5176,7 @@
       "position": 367,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5190,7 +5190,7 @@
       "position": 368,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite CosPLA filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5204,12 +5204,12 @@
       "position": 369,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite LW-PLA filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker PolyLite CosPLA filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "PolyLite LW-PLA",
+        "category": "PolyLite CosPLA",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -5218,7 +5218,7 @@
       "position": 370,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite LW-PLA filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker PolyLite LW-PLA filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5232,7 +5232,7 @@
       "position": 371,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyLite LW-PLA filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker PolyLite LW-PLA filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5246,6 +5246,20 @@
       "position": 372,
       "item": {
         "@type": "Product",
+        "name": "Polymaker PolyLite LW-PLA filament preset for Bambu Lab X2D (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyLite LW-PLA",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 373,
+      "item": {
+        "@type": "Product",
         "name": "Polymaker PolyLite PC filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
@@ -5257,7 +5271,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 373,
+      "position": 374,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5271,7 +5285,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 374,
+      "position": 375,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5285,7 +5299,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 375,
+      "position": 376,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5299,7 +5313,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 376,
+      "position": 377,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -5313,7 +5327,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 377,
+      "position": 378,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -5327,7 +5341,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 378,
+      "position": 379,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5341,7 +5355,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 379,
+      "position": 380,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5355,7 +5369,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 380,
+      "position": 381,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5369,7 +5383,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 381,
+      "position": 382,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -5383,7 +5397,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 382,
+      "position": 383,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -5397,7 +5411,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 383,
+      "position": 384,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -5411,7 +5425,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 384,
+      "position": 385,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -5425,7 +5439,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 385,
+      "position": 386,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -5439,7 +5453,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 386,
+      "position": 387,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -5453,7 +5467,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 387,
+      "position": 388,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5467,7 +5481,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 388,
+      "position": 389,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -5481,7 +5495,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 389,
+      "position": 390,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -5495,7 +5509,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 390,
+      "position": 391,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5509,7 +5523,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 391,
+      "position": 392,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -5523,7 +5537,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 392,
+      "position": 393,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -5537,7 +5551,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 393,
+      "position": 394,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5551,7 +5565,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 394,
+      "position": 395,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -5565,7 +5579,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 395,
+      "position": 396,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -5579,7 +5593,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 396,
+      "position": 397,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5593,7 +5607,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 397,
+      "position": 398,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -5607,7 +5621,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 398,
+      "position": 399,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Prusa Core One (PrusaSlicer)",
@@ -5621,7 +5635,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 399,
+      "position": 400,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -5635,7 +5649,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 400,
+      "position": 401,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -5649,7 +5663,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 401,
+      "position": 402,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -5663,7 +5677,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 402,
+      "position": 403,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -5677,7 +5691,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 403,
+      "position": 404,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -5691,7 +5705,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 404,
+      "position": 405,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5705,7 +5719,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 405,
+      "position": 406,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -5719,7 +5733,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 406,
+      "position": 407,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -5733,7 +5747,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 407,
+      "position": 408,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5747,7 +5761,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 408,
+      "position": 409,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -5761,7 +5775,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 409,
+      "position": 410,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -5775,7 +5789,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 410,
+      "position": 411,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5789,7 +5803,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 411,
+      "position": 412,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -5803,7 +5817,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 412,
+      "position": 413,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -5817,7 +5831,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 413,
+      "position": 414,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5831,7 +5845,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 414,
+      "position": 415,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -5845,7 +5859,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 415,
+      "position": 416,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Prusa Core One (PrusaSlicer)",
@@ -5859,7 +5873,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 416,
+      "position": 417,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -5873,7 +5887,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 417,
+      "position": 418,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -5887,7 +5901,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 418,
+      "position": 419,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -5901,7 +5915,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 419,
+      "position": 420,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -5915,7 +5929,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 420,
+      "position": 421,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -5929,7 +5943,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 421,
+      "position": 422,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5943,7 +5957,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 422,
+      "position": 423,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -5957,7 +5971,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 423,
+      "position": 424,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -5971,7 +5985,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 424,
+      "position": 425,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5985,7 +5999,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 425,
+      "position": 426,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -5999,7 +6013,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 426,
+      "position": 427,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -6013,7 +6027,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 427,
+      "position": 428,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6027,7 +6041,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 428,
+      "position": 429,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -6041,7 +6055,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 429,
+      "position": 430,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -6055,7 +6069,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 430,
+      "position": 431,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -6069,7 +6083,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 431,
+      "position": 432,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -6083,7 +6097,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 432,
+      "position": 433,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Prusa Core One (PrusaSlicer)",
@@ -6097,7 +6111,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 433,
+      "position": 434,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -6111,7 +6125,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 434,
+      "position": 435,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -6125,7 +6139,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 435,
+      "position": 436,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -6139,7 +6153,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 436,
+      "position": 437,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -6153,7 +6167,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 437,
+      "position": 438,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -6167,7 +6181,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 438,
+      "position": 439,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -6181,7 +6195,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 439,
+      "position": 440,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -6195,7 +6209,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 440,
+      "position": 441,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -6209,7 +6223,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 441,
+      "position": 442,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -6223,7 +6237,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 442,
+      "position": 443,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -6237,7 +6251,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 443,
+      "position": 444,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -6251,7 +6265,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 444,
+      "position": 445,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6265,7 +6279,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 445,
+      "position": 446,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -6279,7 +6293,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 446,
+      "position": 447,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -6293,7 +6307,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 447,
+      "position": 448,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -6307,7 +6321,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 448,
+      "position": 449,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -6321,7 +6335,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 449,
+      "position": 450,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Prusa Core One (PrusaSlicer)",
@@ -6335,7 +6349,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 450,
+      "position": 451,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -6349,7 +6363,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 451,
+      "position": 452,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -6363,7 +6377,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 452,
+      "position": 453,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -6377,7 +6391,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 453,
+      "position": 454,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -6391,7 +6405,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 454,
+      "position": 455,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -6405,7 +6419,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 455,
+      "position": 456,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -6419,7 +6433,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 456,
+      "position": 457,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -6433,7 +6447,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 457,
+      "position": 458,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -6447,7 +6461,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 458,
+      "position": 459,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -6461,7 +6475,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 459,
+      "position": 460,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -6475,7 +6489,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 460,
+      "position": 461,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -6489,7 +6503,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 461,
+      "position": 462,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6503,7 +6517,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 462,
+      "position": 463,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -6517,7 +6531,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 463,
+      "position": 464,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -6531,7 +6545,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 464,
+      "position": 465,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -6545,7 +6559,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 465,
+      "position": 466,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -6559,7 +6573,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 466,
+      "position": 467,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Prusa Core One (PrusaSlicer)",
@@ -6573,7 +6587,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 467,
+      "position": 468,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -6587,7 +6601,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 468,
+      "position": 469,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -6601,7 +6615,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 469,
+      "position": 470,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -6615,7 +6629,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 470,
+      "position": 471,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -6629,7 +6643,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 471,
+      "position": 472,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -6643,7 +6657,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 472,
+      "position": 473,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6657,7 +6671,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 473,
+      "position": 474,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -6671,7 +6685,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 474,
+      "position": 475,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -6685,7 +6699,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 475,
+      "position": 476,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Prusa Core One (PrusaSlicer)",
@@ -6699,7 +6713,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 476,
+      "position": 477,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -6713,7 +6727,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 477,
+      "position": 478,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -6727,7 +6741,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 478,
+      "position": 479,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -6741,7 +6755,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 479,
+      "position": 480,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -6755,7 +6769,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 480,
+      "position": 481,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -6769,7 +6783,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 481,
+      "position": 482,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6783,7 +6797,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 482,
+      "position": 483,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -6797,7 +6811,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 483,
+      "position": 484,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -6811,7 +6825,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 484,
+      "position": 485,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Prusa Core One (PrusaSlicer)",
@@ -6825,7 +6839,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 485,
+      "position": 486,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -6839,7 +6853,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 486,
+      "position": 487,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -6853,7 +6867,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 487,
+      "position": 488,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -6867,7 +6881,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 488,
+      "position": 489,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -6881,7 +6895,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 489,
+      "position": 490,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -6895,7 +6909,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 490,
+      "position": 491,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -6909,7 +6923,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 491,
+      "position": 492,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -6923,7 +6937,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 492,
+      "position": 493,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -6937,7 +6951,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 493,
+      "position": 494,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -6951,7 +6965,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 494,
+      "position": 495,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -6965,7 +6979,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 495,
+      "position": 496,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -6979,7 +6993,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 496,
+      "position": 497,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6993,7 +7007,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 497,
+      "position": 498,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -7007,7 +7021,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 498,
+      "position": 499,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -7021,7 +7035,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 499,
+      "position": 500,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7035,7 +7049,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 500,
+      "position": 501,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -7049,7 +7063,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 501,
+      "position": 502,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Prusa Core One (PrusaSlicer)",
@@ -7063,7 +7077,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 502,
+      "position": 503,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7077,7 +7091,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 503,
+      "position": 504,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -7091,7 +7105,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 504,
+      "position": 505,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -7105,7 +7119,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 505,
+      "position": 506,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -7119,7 +7133,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 506,
+      "position": 507,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -7133,7 +7147,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 507,
+      "position": 508,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7147,7 +7161,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 508,
+      "position": 509,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -7161,7 +7175,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 509,
+      "position": 510,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -7175,7 +7189,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 510,
+      "position": 511,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -7189,7 +7203,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 511,
+      "position": 512,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -7203,7 +7217,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 512,
+      "position": 513,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -7217,7 +7231,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 513,
+      "position": 514,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -7231,7 +7245,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 514,
+      "position": 515,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -7245,7 +7259,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 515,
+      "position": 516,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -7259,7 +7273,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 516,
+      "position": 517,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7273,7 +7287,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 517,
+      "position": 518,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -7287,7 +7301,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 518,
+      "position": 519,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Prusa Core One (PrusaSlicer)",
@@ -7301,7 +7315,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 519,
+      "position": 520,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7315,7 +7329,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 520,
+      "position": 521,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA-CF filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7329,7 +7343,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 521,
+      "position": 522,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA-CF filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7343,7 +7357,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 522,
+      "position": 523,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA-CF filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7357,7 +7371,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 523,
+      "position": 524,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PC filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7371,29 +7385,15 @@
     },
     {
       "@type": "ListItem",
-      "position": 524,
-      "item": {
-        "@type": "Product",
-        "name": "Polymaker PolyMax PETG filament preset for Bambu Lab P2S (Bambu Studio)",
-        "brand": {
-          "@type": "Brand",
-          "name": "Polymaker"
-        },
-        "category": "PolyMax PETG",
-        "url": "https://presets.polymaker.com/"
-      }
-    },
-    {
-      "@type": "ListItem",
       "position": 525,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyMax PETG filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker PolyMax PC filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "PolyMax PETG",
+        "category": "PolyMax PC",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -7402,7 +7402,7 @@
       "position": 526,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyMax PETG filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker PolyMax PETG filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -7416,12 +7416,12 @@
       "position": 527,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker PolyMax PETG filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "PolyMax PLA",
+        "category": "PolyMax PETG",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -7430,12 +7430,12 @@
       "position": 528,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker PolyMax PETG filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "PolyMax PLA",
+        "category": "PolyMax PETG",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -7444,12 +7444,12 @@
       "position": 529,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker PolyMax PETG filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "PolyMax PLA",
+        "category": "PolyMax PETG",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -7458,7 +7458,7 @@
       "position": 530,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -7472,7 +7472,7 @@
       "position": 531,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -7486,7 +7486,7 @@
       "position": 532,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyMax PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -7500,7 +7500,7 @@
       "position": 533,
       "item": {
         "@type": "Product",
-        "name": "Polymaker PolyMax PLA filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -7514,6 +7514,48 @@
       "position": 534,
       "item": {
         "@type": "Product",
+        "name": "Polymaker PolyMax PLA filament preset for Bambu Lab X2D (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyMax PLA",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 535,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker PolyMax PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyMax PLA",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 536,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker PolyMax PLA filament preset for Prusa Core One (PrusaSlicer)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyMax PLA",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 537,
+      "item": {
+        "@type": "Product",
         "name": "Polymaker PolySmooth filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
@@ -7525,7 +7567,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 535,
+      "position": 538,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySmooth filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7539,7 +7581,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 536,
+      "position": 539,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySupport filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7553,7 +7595,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 537,
+      "position": 540,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySupport filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7567,7 +7609,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 538,
+      "position": 541,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySupport for PA12 filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7581,7 +7623,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 539,
+      "position": 542,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -7595,7 +7637,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 540,
+      "position": 543,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -7609,7 +7651,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 541,
+      "position": 544,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -7623,7 +7665,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 542,
+      "position": 545,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -7637,7 +7679,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 543,
+      "position": 546,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7651,7 +7693,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 544,
+      "position": 547,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -7665,7 +7707,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 545,
+      "position": 548,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -7679,7 +7721,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 546,
+      "position": 549,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -7693,7 +7735,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 547,
+      "position": 550,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -7707,7 +7749,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 548,
+      "position": 551,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -7721,7 +7763,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 549,
+      "position": 552,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -7735,7 +7777,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 550,
+      "position": 553,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -7749,7 +7791,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 551,
+      "position": 554,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7763,7 +7805,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 552,
+      "position": 555,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -7777,7 +7819,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 553,
+      "position": 556,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Prusa Core One (PrusaSlicer)",
@@ -7791,7 +7833,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 554,
+      "position": 557,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7805,7 +7847,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 555,
+      "position": 558,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -7819,7 +7861,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 556,
+      "position": 559,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -7833,7 +7875,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 557,
+      "position": 560,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -7847,7 +7889,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 558,
+      "position": 561,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -7861,7 +7903,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 559,
+      "position": 562,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7875,7 +7917,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 560,
+      "position": 563,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -7889,7 +7931,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 561,
+      "position": 564,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -7903,7 +7945,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 562,
+      "position": 565,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -7917,7 +7959,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 563,
+      "position": 566,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -7931,7 +7973,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 564,
+      "position": 567,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -7945,7 +7987,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 565,
+      "position": 568,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -7959,7 +8001,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 566,
+      "position": 569,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -7973,7 +8015,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 567,
+      "position": 570,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7987,7 +8029,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 568,
+      "position": 571,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8001,7 +8043,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 569,
+      "position": 572,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Prusa Core One (PrusaSlicer)",
@@ -8015,7 +8057,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 570,
+      "position": 573,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -8029,7 +8071,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 571,
+      "position": 574,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -8043,7 +8085,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 572,
+      "position": 575,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -8057,7 +8099,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 573,
+      "position": 576,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -8071,7 +8113,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 574,
+      "position": 577,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -8085,7 +8127,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 575,
+      "position": 578,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -8099,7 +8141,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 576,
+      "position": 579,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8113,7 +8155,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 577,
+      "position": 580,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -8127,7 +8169,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 578,
+      "position": 581,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -8141,7 +8183,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 579,
+      "position": 582,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8155,7 +8197,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 580,
+      "position": 583,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -8169,7 +8211,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 581,
+      "position": 584,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -8183,7 +8225,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 582,
+      "position": 585,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8197,7 +8239,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 583,
+      "position": 586,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8211,7 +8253,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 584,
+      "position": 587,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Prusa Core One (PrusaSlicer)",
@@ -8225,7 +8267,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 585,
+      "position": 588,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -8239,7 +8281,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 586,
+      "position": 589,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -8253,7 +8295,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 587,
+      "position": 590,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -8267,7 +8309,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 588,
+      "position": 591,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8281,7 +8323,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 589,
+      "position": 592,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -8295,7 +8337,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 590,
+      "position": 593,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8309,7 +8351,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 591,
+      "position": 594,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8323,7 +8365,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 592,
+      "position": 595,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for CreealityPrint K2Pro (CrealityPrint)",
@@ -8337,7 +8379,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 593,
+      "position": 596,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8351,7 +8393,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 594,
+      "position": 597,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for QIDI Q2 (OrcaSlicer)",
@@ -8365,7 +8407,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 595,
+      "position": 598,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Anycubic Kobra S1 (OrcaSlicer)",
@@ -8379,7 +8421,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 596,
+      "position": 599,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -8393,7 +8435,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 597,
+      "position": 600,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -8407,7 +8449,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 598,
+      "position": 601,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8421,7 +8463,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 599,
+      "position": 602,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -8435,7 +8477,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 600,
+      "position": 603,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8449,7 +8491,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 601,
+      "position": 604,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8463,7 +8505,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 602,
+      "position": 605,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for CreealityPrint K2Pro (CrealityPrint)",
@@ -8477,7 +8519,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 603,
+      "position": 606,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8491,7 +8533,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 604,
+      "position": 607,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -8505,7 +8547,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 605,
+      "position": 608,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Anycubic Kobra S1 (OrcaSlicer)",
@@ -8519,7 +8561,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 606,
+      "position": 609,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -8533,7 +8575,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 607,
+      "position": 610,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -8547,7 +8589,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 608,
+      "position": 611,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8561,7 +8603,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 609,
+      "position": 612,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -8575,7 +8617,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 610,
+      "position": 613,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8589,7 +8631,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 611,
+      "position": 614,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8603,7 +8645,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 612,
+      "position": 615,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for CreealityPrint K2Pro (CrealityPrint)",
@@ -8617,7 +8659,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 613,
+      "position": 616,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8631,7 +8673,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 614,
+      "position": 617,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -8645,7 +8687,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 615,
+      "position": 618,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ASA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -8659,7 +8701,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 616,
+      "position": 619,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ASA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8673,7 +8715,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 617,
+      "position": 620,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ASA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8687,7 +8729,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 618,
+      "position": 621,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Polymaker ASA filament preset for CreealityPrint K2Pro (CrealityPrint)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Polymaker ASA",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 622,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -8701,7 +8757,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 619,
+      "position": 623,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -8715,7 +8771,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 620,
+      "position": 624,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -8729,7 +8785,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 621,
+      "position": 625,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8743,7 +8799,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 622,
+      "position": 626,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -8757,7 +8813,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 623,
+      "position": 627,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8771,7 +8827,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 624,
+      "position": 628,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8785,7 +8841,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 625,
+      "position": 629,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8799,7 +8855,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 626,
+      "position": 630,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Prusa Core One (PrusaSlicer)",
@@ -8813,7 +8869,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 627,
+      "position": 631,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -8827,66 +8883,10 @@
     },
     {
       "@type": "ListItem",
-      "position": 628,
-      "item": {
-        "@type": "Product",
-        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab H2C (Bambu Studio)",
-        "brand": {
-          "@type": "Brand",
-          "name": "Polymaker"
-        },
-        "category": "Polymaker HT-PLA-GF",
-        "url": "https://presets.polymaker.com/"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 629,
-      "item": {
-        "@type": "Product",
-        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab H2D (Bambu Studio)",
-        "brand": {
-          "@type": "Brand",
-          "name": "Polymaker"
-        },
-        "category": "Polymaker HT-PLA-GF",
-        "url": "https://presets.polymaker.com/"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 630,
-      "item": {
-        "@type": "Product",
-        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab H2S (Bambu Studio)",
-        "brand": {
-          "@type": "Brand",
-          "name": "Polymaker"
-        },
-        "category": "Polymaker HT-PLA-GF",
-        "url": "https://presets.polymaker.com/"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 631,
-      "item": {
-        "@type": "Product",
-        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab P2S (Bambu Studio)",
-        "brand": {
-          "@type": "Brand",
-          "name": "Polymaker"
-        },
-        "category": "Polymaker HT-PLA-GF",
-        "url": "https://presets.polymaker.com/"
-      }
-    },
-    {
-      "@type": "ListItem",
       "position": 632,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -8900,7 +8900,7 @@
       "position": 633,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -8914,7 +8914,7 @@
       "position": 634,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -8928,7 +8928,7 @@
       "position": 635,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -8942,12 +8942,12 @@
       "position": 636,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG",
+        "category": "Polymaker HT-PLA-GF",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -8956,12 +8956,12 @@
       "position": 637,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG",
+        "category": "Polymaker HT-PLA-GF",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -8970,12 +8970,12 @@
       "position": 638,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG",
+        "category": "Polymaker HT-PLA-GF",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -8984,12 +8984,12 @@
       "position": 639,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG",
+        "category": "Polymaker HT-PLA-GF",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -8998,12 +8998,12 @@
       "position": 640,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Polymaker HT-PLA-GF filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG",
+        "category": "Polymaker HT-PLA-GF",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9012,7 +9012,7 @@
       "position": 641,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9026,7 +9026,7 @@
       "position": 642,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9040,7 +9040,7 @@
       "position": 643,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9054,7 +9054,7 @@
       "position": 644,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9068,7 +9068,7 @@
       "position": 645,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9082,7 +9082,7 @@
       "position": 646,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9096,12 +9096,12 @@
       "position": 647,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG Galaxy",
+        "category": "Polymaker PETG",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9110,12 +9110,12 @@
       "position": 648,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG Galaxy",
+        "category": "Polymaker PETG",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9124,12 +9124,12 @@
       "position": 649,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG Galaxy",
+        "category": "Polymaker PETG",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9138,12 +9138,12 @@
       "position": 650,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG Galaxy",
+        "category": "Polymaker PETG",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9152,12 +9152,12 @@
       "position": 651,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PETG Galaxy",
+        "category": "Polymaker PETG",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9166,7 +9166,7 @@
       "position": 652,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9180,7 +9180,7 @@
       "position": 653,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9194,7 +9194,7 @@
       "position": 654,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9208,7 +9208,7 @@
       "position": 655,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9222,7 +9222,7 @@
       "position": 656,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9236,7 +9236,7 @@
       "position": 657,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PETG Galaxy filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9250,12 +9250,12 @@
       "position": 658,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA",
+        "category": "Polymaker PETG Galaxy",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9264,12 +9264,12 @@
       "position": 659,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA",
+        "category": "Polymaker PETG Galaxy",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9278,12 +9278,12 @@
       "position": 660,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA",
+        "category": "Polymaker PETG Galaxy",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9292,12 +9292,12 @@
       "position": 661,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA",
+        "category": "Polymaker PETG Galaxy",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9306,12 +9306,12 @@
       "position": 662,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Polymaker PETG Galaxy filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA",
+        "category": "Polymaker PETG Galaxy",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9320,7 +9320,7 @@
       "position": 663,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9334,7 +9334,7 @@
       "position": 664,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9348,7 +9348,7 @@
       "position": 665,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9362,12 +9362,12 @@
       "position": 666,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Anycubic Kobra S1 (OrcaSlicer)",
+        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro",
+        "category": "Polymaker PLA",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9376,12 +9376,12 @@
       "position": 667,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro",
+        "category": "Polymaker PLA",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9390,12 +9390,12 @@
       "position": 668,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro",
+        "category": "Polymaker PLA",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9404,12 +9404,12 @@
       "position": 669,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro",
+        "category": "Polymaker PLA",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9418,12 +9418,12 @@
       "position": 670,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro",
+        "category": "Polymaker PLA",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9432,12 +9432,12 @@
       "position": 671,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro",
+        "category": "Polymaker PLA",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9446,7 +9446,7 @@
       "position": 672,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Anycubic Kobra S1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9460,7 +9460,7 @@
       "position": 673,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9474,7 +9474,7 @@
       "position": 674,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9488,7 +9488,7 @@
       "position": 675,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9502,7 +9502,7 @@
       "position": 676,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9516,7 +9516,7 @@
       "position": 677,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9530,12 +9530,12 @@
       "position": 678,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Anycubic Kobra S1 (OrcaSlicer)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro Metallic",
+        "category": "Polymaker PLA Pro",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9544,12 +9544,12 @@
       "position": 679,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro Metallic",
+        "category": "Polymaker PLA Pro",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9558,12 +9558,12 @@
       "position": 680,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro Metallic",
+        "category": "Polymaker PLA Pro",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9572,12 +9572,12 @@
       "position": 681,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro Metallic",
+        "category": "Polymaker PLA Pro",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9586,12 +9586,12 @@
       "position": 682,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro Metallic",
+        "category": "Polymaker PLA Pro",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9600,12 +9600,12 @@
       "position": 683,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Polymaker PLA Pro Metallic",
+        "category": "Polymaker PLA Pro",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -9614,7 +9614,7 @@
       "position": 684,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Anycubic Kobra S1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9628,7 +9628,7 @@
       "position": 685,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9642,7 +9642,7 @@
       "position": 686,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9656,7 +9656,7 @@
       "position": 687,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9670,7 +9670,7 @@
       "position": 688,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -9682,6 +9682,90 @@
     {
       "@type": "ListItem",
       "position": 689,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab H2S (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Polymaker PLA Pro Metallic",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 690,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab P1S (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Polymaker PLA Pro Metallic",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 691,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab P2S (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Polymaker PLA Pro Metallic",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 692,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab X2D (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Polymaker PLA Pro Metallic",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 693,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Polymaker PLA Pro Metallic",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 694,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Prusa Core One (PrusaSlicer)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Polymaker PLA Pro Metallic",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 695,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -9947,7 +10031,7 @@
     <noscript>
     <section class="card seo-content" id="about-presets" aria-labelledby="about-presets-title">
       <h2 id="about-presets-title" class="seo-content-title">Polymaker filament presets for Bambu Studio, OrcaSlicer, ElegooSlicer &amp; PrusaSlicer</h2>
-      <p>Download free, official Polymaker print profiles and 3D printing filament presets. This page provides 689 ready-to-use presets covering 66 Polymaker materials, tuned for Bambu Studio, CrealityPrint, ElegooSlicer, OrcaSlicer, PrusaSlicer. Each preset sets the recommended nozzle and bed temperature, flow rate, cooling, and other parameters so your Polymaker filament prints correctly on the first try.</p>
+      <p>Download free, official Polymaker print profiles and 3D printing filament presets. This page provides 695 ready-to-use presets covering 66 Polymaker materials, tuned for Bambu Studio, CrealityPrint, ElegooSlicer, OrcaSlicer, PrusaSlicer. Each preset sets the recommended nozzle and bed temperature, flow rate, cooling, and other parameters so your Polymaker filament prints correctly on the first try.</p>
       <p>Presets are organized by slicer, material, printer brand, and printer model. Whether you need a PolyLite PETG preset for the Bambu Lab X1 Carbon, a Fiberon ASA-CF preset for Bambu Studio, or a PolyTerra PLA profile for OrcaSlicer, use the filters above to download the exact preset file for your printer.</p>
 
       <h3 class="seo-section-title">Materials with presets</h3>

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updatedAt": "2026-07-02T08:50:28.961Z",
+  "updatedAt": "2026-07-21T08:54:36.207Z",
   "materials": [
     "Fiberon ASA-CF08",
     "Fiberon PA12-CF10",
@@ -210,7 +210,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Fiberon ASA-CF08/Elegoo/CC2/ElegooSlicer/Fiberon ASA-CF08 @Elegoo CC2.json",
       "filename": "Fiberon ASA-CF08 @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -236,7 +236,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Fiberon ASA-CF08/Snapmaker/U1/OrcaSlicer/Fiberon ASA-CF08 @Snapmaker U1.json",
       "filename": "Fiberon ASA-CF08 @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -405,7 +405,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Fiberon PA12-CF10/Elegoo/CC2/ElegooSlicer/Fiberon PA12-CF10 @Elegoo CC2.json",
       "filename": "Fiberon PA12-CF10 @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -421,7 +421,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Fiberon PA12-CF10/Snapmaker/U1/OrcaSlicer/Fiberon PA12-CF10 @Snapmaker U1.json",
       "filename": "Fiberon PA12-CF10 @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -437,7 +437,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Fiberon PA6-CF20/Anycubic/Kobra S1/OrcaSlicer/Fiberon PA6-CF20 @Anycubic Kobra S1.json",
       "filename": "Fiberon PA6-CF20 @Anycubic Kobra S1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Anycubic",
@@ -607,7 +607,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Fiberon PA6-CF20/Elegoo/CC2/ElegooSlicer/Fiberon PA6-CF20 @Elegoo CC2.json",
       "filename": "Fiberon PA6-CF20 @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -798,7 +798,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Fiberon PA6-GF25/Elegoo/CC2/ElegooSlicer/Fiberon PA6-GF25 @Elegoo CC2.json",
       "filename": "Fiberon PA6-GF25 @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -978,7 +978,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Fiberon PA612-CF15/Elegoo/CC2/ElegooSlicer/Fiberon PA612-CF15 @Elegoo CC2.json",
       "filename": "Fiberon PA612-CF15 @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -1099,7 +1099,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Fiberon PA612-ESD/Elegoo/CC2/ElegooSlicer/Fiberon PA612-ESD @Elegoo CC2.json",
       "filename": "Fiberon PA612-ESD @Elegoo CC2.json",
-      "updatedAt": "2026-06-02T13:09:24+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -1279,7 +1279,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Fiberon PET-CF17/Elegoo/CC2/ElegooSlicer/Fiberon PET-CF17 @Elegoo CC2.json",
       "filename": "Fiberon PET-CF17 @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -1295,7 +1295,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Fiberon PET-CF17/Snapmaker/U1/OrcaSlicer/Fiberon PET-CF17 @Snapmaker U1.json",
       "filename": "Fiberon PET-CF17 @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -1330,7 +1330,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-GF15/BBL/H2D/BambuStudio/Fiberon PET-GF15 @BBL H2D.json",
       "filename": "Fiberon PET-GF15 @BBL H2D.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1405,7 +1405,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Fiberon PET-GF15/Elegoo/CC2/ElegooSlicer/Fiberon PET-GF15 @Elegoo CC2.json",
       "filename": "Fiberon PET-GF15 @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -1421,7 +1421,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Fiberon PET-GF15/Snapmaker/U1/OrcaSlicer/Fiberon PET-GF15 @Snapmaker U1.json",
       "filename": "Fiberon PET-GF15 @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -1577,7 +1577,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Fiberon PETG-ESD/Elegoo/CC2/ElegooSlicer/Fiberon PETG-ESD @Elegoo CC2.json",
       "filename": "Fiberon PETG-ESD @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -1593,7 +1593,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Fiberon PETG-ESD/Snapmaker/U1/OrcaSlicer/Fiberon PETG-ESD @Snapmaker U1.json",
       "filename": "Fiberon PETG-ESD @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -1784,7 +1784,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PPS-CF10/BBL/H2D/BambuStudio/Fiberon PPS-CF10 @BBL H2D.json",
       "filename": "Fiberon PPS-CF10 @BBL H2D.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2163,7 +2163,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma CoPE/Elegoo/CC2/ElegooSlicer/Panchroma CoPE @Elegoo CC2.json",
       "filename": "Panchroma CoPE @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -2205,7 +2205,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Panchroma PLA/Anycubic/Kobra S1/OrcaSlicer/Panchroma PLA @Anycubic Kobra S1.json",
       "filename": "Panchroma PLA @Anycubic Kobra S1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Anycubic",
@@ -2514,7 +2514,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA/Elegoo/CC2/ElegooSlicer/Panchroma PLA @Elegoo CC2.json",
       "filename": "Panchroma PLA @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -2824,7 +2824,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Celestial/Elegoo/CC2/ElegooSlicer/Panchroma PLA Celestial @Elegoo CC2.json",
       "filename": "Panchroma PLA Celestial @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -3134,7 +3134,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Galaxy/Elegoo/CC2/ElegooSlicer/Panchroma PLA Galaxy @Elegoo CC2.json",
       "filename": "Panchroma PLA Galaxy @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -3444,7 +3444,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Glow/Elegoo/CC2/ElegooSlicer/Panchroma PLA Glow @Elegoo CC2.json",
       "filename": "Panchroma PLA Glow @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -3754,7 +3754,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Luminous/Elegoo/CC2/ElegooSlicer/Panchroma PLA Luminous @Elegoo CC2.json",
       "filename": "Panchroma PLA Luminous @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -3880,7 +3880,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/A2L/BambuStudio/Panchroma PLA Marble @BBL A2L.json",
       "filename": "Panchroma PLA Marble @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -4048,7 +4048,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Marble/Elegoo/CC2/ElegooSlicer/Panchroma PLA Marble @Elegoo CC2.json",
       "filename": "Panchroma PLA Marble @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -4174,7 +4174,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/A2L/BambuStudio/Panchroma PLA Matte @BBL A2L.json",
       "filename": "Panchroma PLA Matte @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -4342,7 +4342,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Matte/Elegoo/CC2/ElegooSlicer/Panchroma PLA Matte @Elegoo CC2.json",
       "filename": "Panchroma PLA Matte @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -4652,7 +4652,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Metallic/Elegoo/CC2/ElegooSlicer/Panchroma PLA Metallic @Elegoo CC2.json",
       "filename": "Panchroma PLA Metallic @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -4962,7 +4962,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Neon/Elegoo/CC2/ElegooSlicer/Panchroma PLA Neon @Elegoo CC2.json",
       "filename": "Panchroma PLA Neon @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -5246,7 +5246,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Satin/Elegoo/CC2/ElegooSlicer/Panchroma PLA Satin @Elegoo CC2.json",
       "filename": "Panchroma PLA Satin @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -5556,7 +5556,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Silk/Elegoo/CC2/ElegooSlicer/Panchroma PLA Silk @Elegoo CC2.json",
       "filename": "Panchroma PLA Silk @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -5866,7 +5866,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Starlight/Elegoo/CC2/ElegooSlicer/Panchroma PLA Starlight @Elegoo CC2.json",
       "filename": "Panchroma PLA Starlight @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -6176,7 +6176,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA Translucent/Elegoo/CC2/ElegooSlicer/Panchroma PLA Translucent @Elegoo CC2.json",
       "filename": "Panchroma PLA Translucent @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -6486,7 +6486,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA UV Shift/Elegoo/CC2/ElegooSlicer/Panchroma PLA UV Shift @Elegoo CC2.json",
       "filename": "Panchroma PLA UV Shift @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -6528,7 +6528,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyCast/BBL/A2L/BambuStudio/PolyCast @BBL A2L.json",
       "filename": "PolyCast @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -6538,7 +6538,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyCast/BBL/P2S/BambuStudio/PolyCast @BBL P2S.json",
       "filename": "PolyCast @BBL P2S.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6616,13 +6616,29 @@
       ]
     },
     {
+      "material": "PolyFlex TPU95",
+      "brand": "Elegoo",
+      "model": "CC2",
+      "slicer": "ElegooSlicer",
+      "path": "preset/PolyFlex TPU95/Elegoo/CC2/ElegooSlicer/PolyFlex TPU95 @Elegoo CC2.json",
+      "filename": "PolyFlex TPU95 @Elegoo CC2.json",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "Elegoo",
+          "model": "CC2",
+          "fullName": "Elegoo Centauri Carbon 2 0.4 nozzle"
+        }
+      ]
+    },
+    {
       "material": "PolyFlex TPU95-HF",
       "brand": "BBL",
       "model": "A2L",
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95-HF/BBL/A2L/BambuStudio/PolyFlex TPU95-HF @BBL A2L.json",
       "filename": "PolyFlex TPU95-HF @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -6955,7 +6971,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite CosPLA/Elegoo/CC2/ElegooSlicer/PolyLite CosPLA @Elegoo CC2.json",
       "filename": "PolyLite CosPLA @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -7068,7 +7084,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PETG/BBL/A2L/BambuStudio/PolyLite PETG @BBL A2L.json",
       "filename": "PolyLite PETG @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -7118,7 +7134,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PETG/Elegoo/CC2/ElegooSlicer/PolyLite PETG @Elegoo CC2.json",
       "filename": "PolyLite PETG @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -7134,7 +7150,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/PolyLite PETG/Snapmaker/U1/OrcaSlicer/PolyLite PETG @Snapmaker U1.json",
       "filename": "PolyLite PETG @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -7150,7 +7166,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PETG Translucent/BBL/A2L/BambuStudio/PolyLite PETG Translucent @BBL A2L.json",
       "filename": "PolyLite PETG Translucent @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -7200,7 +7216,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PETG Translucent/Elegoo/CC2/ElegooSlicer/PolyLite PETG Translucent @Elegoo CC2.json",
       "filename": "PolyLite PETG Translucent @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -7216,7 +7232,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/PolyLite PETG Translucent/Snapmaker/U1/OrcaSlicer/PolyLite PETG Translucent @Snapmaker U1.json",
       "filename": "PolyLite PETG Translucent @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -7500,7 +7516,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA/Elegoo/CC2/ElegooSlicer/PolyLite PLA @Elegoo CC2.json",
       "filename": "PolyLite PLA @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -7810,7 +7826,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA Galaxy/Elegoo/CC2/ElegooSlicer/PolyLite PLA Galaxy @Elegoo CC2.json",
       "filename": "PolyLite PLA Galaxy @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -8120,7 +8136,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA Glow/Elegoo/CC2/ElegooSlicer/PolyLite PLA Glow @Elegoo CC2.json",
       "filename": "PolyLite PLA Glow @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -8430,7 +8446,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA Luminous/Elegoo/CC2/ElegooSlicer/PolyLite PLA Luminous @Elegoo CC2.json",
       "filename": "PolyLite PLA Luminous @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -8740,7 +8756,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA Neon/Elegoo/CC2/ElegooSlicer/PolyLite PLA Neon @Elegoo CC2.json",
       "filename": "PolyLite PLA Neon @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -8872,7 +8888,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA Pro/Elegoo/CC2/ElegooSlicer/PolyLite PLA Pro @Elegoo CC2.json",
       "filename": "PolyLite PLA Pro @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -9004,7 +9020,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA Pro Metallic/Elegoo/CC2/ElegooSlicer/PolyLite PLA Pro Metallic @Elegoo CC2.json",
       "filename": "PolyLite PLA Pro Metallic @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -9314,7 +9330,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA Starlight/Elegoo/CC2/ElegooSlicer/PolyLite PLA Starlight @Elegoo CC2.json",
       "filename": "PolyLite PLA Starlight @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -9624,7 +9640,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA Translucent/Elegoo/CC2/ElegooSlicer/PolyLite PLA Translucent @Elegoo CC2.json",
       "filename": "PolyLite PLA Translucent @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -9697,7 +9713,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/PolyLite PLA-CF/Snapmaker/U1/OrcaSlicer/PolyLite PLA-CF @Snapmaker U1.json",
       "filename": "PolyLite PLA-CF @Snapmaker U1.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -9713,7 +9729,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PC/BBL/X2D/BambuStudio/PolyMax PC @BBL X2D.json",
       "filename": "PolyMax PC @BBL X2D.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9726,6 +9742,32 @@
         "Bowden Standard",
         "Bowden High Flow"
       ]
+    },
+    {
+      "material": "PolyMax PC",
+      "brand": "Elegoo",
+      "model": "CC2",
+      "slicer": "ElegooSlicer",
+      "path": "preset/PolyMax PC/Elegoo/CC2/ElegooSlicer/PolyMax PC @Elegoo CC2.json",
+      "filename": "PolyMax PC @Elegoo CC2.json",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "Elegoo",
+          "model": "CC2",
+          "fullName": "Elegoo Centauri Carbon 2 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "PolyMax PETG",
+      "brand": "BBL",
+      "model": "A2L",
+      "slicer": "BambuStudio",
+      "path": "preset/PolyMax PETG/BBL/A2L/BambuStudio/PolyMax PETG @BBL A2L.json",
+      "filename": "PolyMax PETG @BBL A2L.json",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
+      "compatiblePrinters": []
     },
     {
       "material": "PolyMax PETG",
@@ -9769,7 +9811,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyMax PETG/Elegoo/CC2/ElegooSlicer/PolyMax PETG @Elegoo CC2.json",
       "filename": "PolyMax PETG @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -9864,7 +9906,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyMax PLA/Elegoo/CC2/ElegooSlicer/PolyMax PLA @Elegoo CC2.json",
       "filename": "PolyMax PLA @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -10050,7 +10092,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/A2L/BambuStudio/PolyTerra PLA @BBL A2L.json",
       "filename": "PolyTerra PLA @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -10218,7 +10260,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyTerra PLA/Elegoo/CC2/ElegooSlicer/PolyTerra PLA @Elegoo CC2.json",
       "filename": "PolyTerra PLA @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -10344,7 +10386,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/A2L/BambuStudio/PolyTerra PLA Marble @BBL A2L.json",
       "filename": "PolyTerra PLA Marble @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -10512,7 +10554,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyTerra PLA Marble/Elegoo/CC2/ElegooSlicer/PolyTerra PLA Marble @Elegoo CC2.json",
       "filename": "PolyTerra PLA Marble @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -10796,7 +10838,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyTerra PLA+/Elegoo/CC2/ElegooSlicer/PolyTerra PLA+ @Elegoo CC2.json",
       "filename": "PolyTerra PLA+ @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -10876,7 +10918,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Max/BBL/H2S/BambuStudio/Polymaker ABS Max @BBL H2S.json",
       "filename": "Polymaker ABS Max @BBL H2S.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10966,7 +11008,7 @@
       "slicer": "CrealityPrint",
       "path": "preset/Polymaker ABS Max/CreealityPrint/K2Pro/CrealityPrint/Polymaker ABS Max @CreealityPrint K2Pro.json",
       "filename": "Polymaker ABS Max @CreealityPrint K2Pro.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -10976,7 +11018,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker ABS Max/Elegoo/CC2/ElegooSlicer/Polymaker ABS Max @Elegoo CC2.json",
       "filename": "Polymaker ABS Max @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -11002,7 +11044,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker ABS Pro/Anycubic/Kobra S1/OrcaSlicer/Polymaker ABS Pro @Anycubic Kobra S1.json",
       "filename": "Polymaker ABS Pro @Anycubic Kobra S1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Anycubic",
@@ -11153,7 +11195,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker ABS Pro/Elegoo/CC2/ElegooSlicer/Polymaker ABS Pro @Elegoo CC2.json",
       "filename": "Polymaker ABS Pro @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -11169,7 +11211,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker ABS Pro/Snapmaker/U1/OrcaSlicer/Polymaker ABS Pro @Snapmaker U1.json",
       "filename": "Polymaker ABS Pro @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -11185,7 +11227,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker ABS Pro Galaxy/Anycubic/Kobra S1/OrcaSlicer/Polymaker ABS Pro Galaxy @Anycubic Kobra S1.json",
       "filename": "Polymaker ABS Pro Galaxy @Anycubic Kobra S1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Anycubic",
@@ -11336,7 +11378,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker ABS Pro Galaxy/Elegoo/CC2/ElegooSlicer/Polymaker ABS Pro Galaxy @Elegoo CC2.json",
       "filename": "Polymaker ABS Pro Galaxy @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -11352,7 +11394,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker ABS Pro Galaxy/Snapmaker/U1/OrcaSlicer/Polymaker ABS Pro Galaxy @Snapmaker U1.json",
       "filename": "Polymaker ABS Pro Galaxy @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -11406,7 +11448,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ASA/BBL/X2D/BambuStudio/Polymaker ASA @BBL X2D.json",
       "filename": "Polymaker ASA @BBL X2D.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11414,6 +11456,16 @@
           "fullName": "Bambu Lab X2D 0.4 nozzle"
         }
       ]
+    },
+    {
+      "material": "Polymaker ASA",
+      "brand": "CreealityPrint",
+      "model": "K2Pro",
+      "slicer": "CrealityPrint",
+      "path": "preset/Polymaker ASA/CreealityPrint/K2Pro/CrealityPrint/Polymaker ASA @CreealityPrint K2Pro.json",
+      "filename": "Polymaker ASA @CreealityPrint K2Pro.json",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
+      "compatiblePrinters": []
     },
     {
       "material": "Polymaker HT-PLA",
@@ -11548,7 +11600,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker HT-PLA/Elegoo/CC2/ElegooSlicer/Polymaker HT-PLA @Elegoo CC2.json",
       "filename": "Polymaker HT-PLA @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -11574,7 +11626,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker HT-PLA/Snapmaker/U1/OrcaSlicer/Polymaker HT-PLA @Snapmaker U1.json",
       "filename": "Polymaker HT-PLA @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -11582,6 +11634,16 @@
           "fullName": "Snapmaker U1 (0.4 nozzle)"
         }
       ]
+    },
+    {
+      "material": "Polymaker HT-PLA-GF",
+      "brand": "BBL",
+      "model": "A2L",
+      "slicer": "BambuStudio",
+      "path": "preset/Polymaker HT-PLA-GF/BBL/A2L/BambuStudio/Polymaker HT-PLA-GF @BBL A2L.json",
+      "filename": "Polymaker HT-PLA-GF @BBL A2L.json",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
+      "compatiblePrinters": []
     },
     {
       "material": "Polymaker HT-PLA-GF",
@@ -11670,7 +11732,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker HT-PLA-GF/Elegoo/CC2/ElegooSlicer/Polymaker HT-PLA-GF @Elegoo CC2.json",
       "filename": "Polymaker HT-PLA-GF @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -11696,7 +11758,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker HT-PLA-GF/Snapmaker/U1/OrcaSlicer/Polymaker HT-PLA-GF @Snapmaker U1.json",
       "filename": "Polymaker HT-PLA-GF @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -11733,7 +11795,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG/BBL/A2L/BambuStudio/Polymaker PETG @BBL A2L.json",
       "filename": "Polymaker PETG @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -11871,7 +11933,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker PETG/Elegoo/CC2/ElegooSlicer/Polymaker PETG @Elegoo CC2.json",
       "filename": "Polymaker PETG @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -11897,7 +11959,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker PETG/Snapmaker/U1/OrcaSlicer/Polymaker PETG @Snapmaker U1.json",
       "filename": "Polymaker PETG @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -11934,7 +11996,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG Galaxy/BBL/A2L/BambuStudio/Polymaker PETG Galaxy @BBL A2L.json",
       "filename": "Polymaker PETG Galaxy @BBL A2L.json",
-      "updatedAt": "2026-07-02T16:49:31+08:00",
+      "updatedAt": "2026-07-02T17:45:22+08:00",
       "compatiblePrinters": []
     },
     {
@@ -12072,7 +12134,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker PETG Galaxy/Elegoo/CC2/ElegooSlicer/Polymaker PETG Galaxy @Elegoo CC2.json",
       "filename": "Polymaker PETG Galaxy @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -12098,7 +12160,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker PETG Galaxy/Snapmaker/U1/OrcaSlicer/Polymaker PETG Galaxy @Snapmaker U1.json",
       "filename": "Polymaker PETG Galaxy @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -12106,6 +12168,16 @@
           "fullName": "Snapmaker U1 (0.4 nozzle)"
         }
       ]
+    },
+    {
+      "material": "Polymaker PLA",
+      "brand": "BBL",
+      "model": "A2L",
+      "slicer": "BambuStudio",
+      "path": "preset/Polymaker PLA/BBL/A2L/BambuStudio/Polymaker PLA @BBL A2L.json",
+      "filename": "Polymaker PLA @BBL A2L.json",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
+      "compatiblePrinters": []
     },
     {
       "material": "Polymaker PLA",
@@ -12194,7 +12266,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker PLA/Elegoo/CC2/ElegooSlicer/Polymaker PLA @Elegoo CC2.json",
       "filename": "Polymaker PLA @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -12220,7 +12292,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker PLA/Snapmaker/U1/OrcaSlicer/Polymaker PLA @Snapmaker U1.json",
       "filename": "Polymaker PLA @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -12236,7 +12308,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker PLA Pro/Anycubic/Kobra S1/OrcaSlicer/Polymaker PLA Pro @Anycubic Kobra S1.json",
       "filename": "Polymaker PLA Pro @Anycubic Kobra S1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Anycubic",
@@ -12399,7 +12471,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker PLA Pro/Elegoo/CC2/ElegooSlicer/Polymaker PLA Pro @Elegoo CC2.json",
       "filename": "Polymaker PLA Pro @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -12425,7 +12497,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker PLA Pro/Snapmaker/U1/OrcaSlicer/Polymaker PLA Pro @Snapmaker U1.json",
       "filename": "Polymaker PLA Pro @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -12441,7 +12513,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker PLA Pro Metallic/Anycubic/Kobra S1/OrcaSlicer/Polymaker PLA Pro Metallic @Anycubic Kobra S1.json",
       "filename": "Polymaker PLA Pro Metallic @Anycubic Kobra S1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Anycubic",
@@ -12604,7 +12676,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker PLA Pro Metallic/Elegoo/CC2/ElegooSlicer/Polymaker PLA Pro Metallic @Elegoo CC2.json",
       "filename": "Polymaker PLA Pro Metallic @Elegoo CC2.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -12630,7 +12702,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker PLA Pro Metallic/Snapmaker/U1/OrcaSlicer/Polymaker PLA Pro Metallic @Snapmaker U1.json",
       "filename": "Polymaker PLA Pro Metallic @Snapmaker U1.json",
-      "updatedAt": "2026-06-17T16:06:55+08:00",
+      "updatedAt": "2026-07-21T16:49:55+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updatedAt": "2026-07-21T08:54:36.207Z",
+  "updatedAt": "2026-07-22T01:20:49.175Z",
   "materials": [
     "Fiberon ASA-CF08",
     "Fiberon PA12-CF10",

--- a/preset/Fiberon ASA-CF08/Elegoo/CC2/ElegooSlicer/Fiberon ASA-CF08 @Elegoo CC2.json
+++ b/preset/Fiberon ASA-CF08/Elegoo/CC2/ElegooSlicer/Fiberon ASA-CF08 @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Fiberon ASA-CF08 @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
     "cool_plate_temp": [
-        "105"
-    ],
-    "eng_plate_temp": [
-        "105"
-    ],
-    "hot_plate_temp": [
-        "105"
-    ],
-    "textured_plate_temp": [
-        "105"
+        "0"
     ],
     "cool_plate_temp_initial_layer": [
-        "105"
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "100"
     ],
     "eng_plate_temp_initial_layer": [
         "105"
     ],
-    "hot_plate_temp_initial_layer": [
-        "105"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "105"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "80"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
-    ],
-    "close_fan_the_first_x_layers": [
-        "1"
-    ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
-    ],
-    "filament_flow_ratio": [
-        "0.96"
-    ],
-    "reduce_fan_stop_start_freq": [
-        "1"
-    ],
     "fan_cooling_layer_time": [
         "6"
     ],
+    "fan_max_speed": [
+        "10"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.09"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.96"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,51 +72,91 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "300"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "fan_min_speed": [
-        "10"
+    "filament_shrink": [
+        "100%"
     ],
-    "slow_down_min_speed": [
-        "30"
+    "hot_plate_temp": [
+        "100"
     ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "105"
     ],
     "nozzle_temperature": [
         "300"
     ],
+    "nozzle_temperature_initial_layer": [
+        "300"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "110.8"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "105"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic ASA @System",
+    "nozzle_temperature_range_high": [
+        "280"
     ],
     "nozzle_temperature_range_low": [
         "260"
     ],
-    "nozzle_temperature_range_high": [
-        "280"
-    ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic ASA",
     "setting_id": "OGFSA04",
     "filament_id": "PMAS01",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon ASA-CF08/Snapmaker/U1/OrcaSlicer/Fiberon ASA-CF08 @Snapmaker U1.json
+++ b/preset/Fiberon ASA-CF08/Snapmaker/U1/OrcaSlicer/Fiberon ASA-CF08 @Snapmaker U1.json
@@ -3,62 +3,56 @@
     "name": "Fiberon ASA-CF08 @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
     "cool_plate_temp": [
-        "105"
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
     ],
     "eng_plate_temp": [
         "100"
     ],
-    "hot_plate_temp": [
-        "100"
-    ],
-    "textured_plate_temp": [
-        "100"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "105"
-    ],
     "eng_plate_temp_initial_layer": [
         "100"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "100"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "100"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "80"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
-    ],
-    "close_fan_the_first_x_layers": [
-        "1"
-    ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
-    ],
-    "filament_flow_ratio": [
-        "0.88"
-    ],
-    "reduce_fan_stop_start_freq": [
-        "1"
     ],
     "fan_cooling_layer_time": [
         "31"
     ],
-    "filament_cost": [
+    "fan_max_speed": [
         "30"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "20"
     ],
     "filament_density": [
         "1.09"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.88"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,51 +72,91 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "100"
+    ],
+    "nozzle_temperature": [
+        "260"
     ],
     "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "full_fan_speed_layer": [
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
         "0"
     ],
-    "fan_max_speed": [
-        "30"
+    "supertack_plate_temp_initial_layer": [
+        "0"
     ],
-    "fan_min_speed": [
-        "10"
-    ],
-    "slow_down_min_speed": [
-        "30"
+    "slow_down_for_layer_cooling": [
+        "1"
     ],
     "slow_down_layer_time": [
         "8"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
-    ],
-    "nozzle_temperature": [
-        "250"
+    "slow_down_min_speed": [
+        "10"
     ],
     "temperature_vitrification": [
         "110.8"
     ],
-    "nozzle_temperature_range_low": [
-        "260"
+    "textured_plate_temp": [
+        "100"
     ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Snapmaker U1 (0.4 nozzle)"
+    ],
+    "inherits": "Generic ASA @System",
     "nozzle_temperature_range_high": [
         "280"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
+    "nozzle_temperature_range_low": [
+        "260"
     ],
     "renamed_from": "My Generic ASA",
     "setting_id": "OGFSA04",
     "filament_id": "PMAS01",
-    "compatible_printers": [
-        "Snapmaker U1 (0.4 nozzle)"
-    ],
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon PA12-CF10/Elegoo/CC2/ElegooSlicer/Fiberon PA12-CF10 @Elegoo CC2.json
+++ b/preset/Fiberon PA12-CF10/Elegoo/CC2/ElegooSlicer/Fiberon PA12-CF10 @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PA12-CF10 @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "90"
-    ],
-    "hot_plate_temp": [
-        "90"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "90"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "90"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.836"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "90"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "90"
     ],
     "fan_cooling_layer_time": [
         "31"
+    ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "10"
     ],
     "filament_cost": [
         "20"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.836"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,36 +72,61 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "hot_plate_temp": [
+        "90"
     ],
-    "fan_min_speed": [
-        "10"
-    ],
-    "slow_down_min_speed": [
-        "10"
-    ],
-    "slow_down_layer_time": [
-        "8"
-    ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "90"
     ],
     "nozzle_temperature": [
         "280"
     ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
     "temperature_vitrification": [
         "55"
     ],
+    "textured_plate_temp": [
+        "50"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "50"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic PC-CF @Elegoo",
     "nozzle_temperature_range_low": [
         "280"
     ],
@@ -116,9 +135,6 @@
     ],
     "filament_id": "PMPA01",
     "setting_id": "GPCCF00",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon PA12-CF10/Snapmaker/U1/OrcaSlicer/Fiberon PA12-CF10 @Snapmaker U1.json
+++ b/preset/Fiberon PA12-CF10/Snapmaker/U1/OrcaSlicer/Fiberon PA12-CF10 @Snapmaker U1.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PA12-CF10 @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "60"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.87"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "50"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "50"
     ],
     "fan_cooling_layer_time": [
         "31"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "20"
     ],
     "filament_cost": [
         "20"
@@ -60,17 +48,17 @@
     "filament_diameter": [
         "1.75"
     ],
+    "filament_flow_ratio": [
+        "0.87"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
     "filament_max_volumetric_speed": [
         "8"
     ],
     "filament_minimal_purge_on_wipe_tower": [
         "15"
-    ],
-    "filament_retraction_length": [
-        "1.0"
-    ],
-    "filament_z_hop": [
-        "0.0"
     ],
     "filament_settings_id": [
         "Fiberon PA12-CF10 @Snapmaker U1"
@@ -84,48 +72,91 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "270"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
         "50"
     ],
-    "fan_min_speed": [
-        "20"
+    "hot_plate_temp_initial_layer": [
+        "50"
     ],
-    "slow_down_min_speed": [
-        "10"
+    "nozzle_temperature": [
+        "280"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "30"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "40"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
     ],
     "slow_down_layer_time": [
         "8"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
-    ],
-    "nozzle_temperature": [
-        "270"
+    "slow_down_min_speed": [
+        "10"
     ],
     "temperature_vitrification": [
         "55"
     ],
-    "nozzle_temperature_range_low": [
-        "280"
+    "textured_plate_temp": [
+        "50"
     ],
-    "nozzle_temperature_range_high": [
-        "300"
+    "textured_plate_temp_initial_layer": [
+        "50"
     ],
-    "renamed_from": "My Generic PA-CF",
-    "setting_id": "OGFSA04",
-    "filament_id": "PMPA01",
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Snapmaker U1 (0.4 nozzle)"
     ],
+    "inherits": "Generic PA-CF @System",
+    "filament_id": "PMPA01",
+    "nozzle_temperature_range_high": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "280"
+    ],
+    "renamed_from": "My Generic PA-CF",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon PA6-CF20/Anycubic/Kobra S1/OrcaSlicer/Fiberon PA6-CF20 @Anycubic Kobra S1.json
+++ b/preset/Fiberon PA6-CF20/Anycubic/Kobra S1/OrcaSlicer/Fiberon PA6-CF20 @Anycubic Kobra S1.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PA6-CF20 @Anycubic Kobra S1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "40"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "40"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "40"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "40"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.95"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "40"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "40"
     ],
     "fan_cooling_layer_time": [
         "15"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "0"
     ],
     "filament_cost": [
         "83.99"
@@ -60,17 +48,17 @@
     "filament_diameter": [
         "1.75"
     ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
     "filament_max_volumetric_speed": [
         "12"
     ],
     "filament_minimal_purge_on_wipe_tower": [
         "15"
-    ],
-    "filament_retraction_length": [
-        "1.0"
-    ],
-    "filament_z_hop": [
-        "0.0"
     ],
     "filament_settings_id": [
         "Fiberon PA6-CF20 @Anycubic Kobra S1"
@@ -84,47 +72,90 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "300"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "0"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "2"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "50"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "50"
     ],
     "nozzle_temperature": [
         "300"
     ],
+    "nozzle_temperature_initial_layer": [
+        "300"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "40"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "74.2"
+    ],
+    "textured_plate_temp": [
+        "40"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "40"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Anycubic Kobra S1 0.4 nozzle"
+    ],
+    "inherits": "Fiberon PA6-CF @System",
+    "filament_id": "PMPA02",
+    "nozzle_temperature_range_high": [
+        "300"
     ],
     "nozzle_temperature_range_low": [
         "280"
     ],
-    "nozzle_temperature_range_high": [
-        "300"
-    ],
-    "filament_id": "PMPA02",
     "setting_id": "OGFSL50_00",
-    "compatible_printers": [
-        "Anycubic Kobra S1 0.4 nozzle"
-    ],
     "filament_extruder_variant": [
         "Direct Drive Standard"
     ],

--- a/preset/Fiberon PA6-CF20/Elegoo/CC2/ElegooSlicer/Fiberon PA6-CF20 @Elegoo CC2.json
+++ b/preset/Fiberon PA6-CF20/Elegoo/CC2/ElegooSlicer/Fiberon PA6-CF20 @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PA6-CF20 @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "90"
-    ],
-    "hot_plate_temp": [
-        "90"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "90"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "90"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.93"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "90"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "90"
     ],
     "fan_cooling_layer_time": [
         "31"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "fan_min_speed": [
+        "10"
     ],
     "filament_cost": [
         "20"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.93"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "4"
@@ -78,36 +72,61 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "30"
+    "hot_plate_temp": [
+        "90"
     ],
-    "fan_min_speed": [
-        "10"
-    ],
-    "slow_down_min_speed": [
-        "10"
-    ],
-    "slow_down_layer_time": [
-        "8"
-    ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "90"
     ],
     "nozzle_temperature": [
         "280"
     ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
     "temperature_vitrification": [
         "74.2"
     ],
+    "textured_plate_temp": [
+        "50"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "50"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic PC-CF @Elegoo",
     "nozzle_temperature_range_low": [
         "280"
     ],
@@ -116,9 +135,6 @@
     ],
     "filament_id": "PMPA02",
     "setting_id": "GPCCF00",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "is_custom_defined": "0",
     "version": "1.3.2.9",
     "idle_temperature": [

--- a/preset/Fiberon PA6-GF25/Elegoo/CC2/ElegooSlicer/Fiberon PA6-GF25 @Elegoo CC2.json
+++ b/preset/Fiberon PA6-GF25/Elegoo/CC2/ElegooSlicer/Fiberon PA6-GF25 @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PA6-GF25 @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "90"
-    ],
-    "hot_plate_temp": [
-        "90"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "90"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "90"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "90"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "90"
     ],
     "fan_cooling_layer_time": [
         "31"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "fan_min_speed": [
+        "10"
     ],
     "filament_cost": [
         "20"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,36 +72,61 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "290"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "30"
+    "hot_plate_temp": [
+        "90"
     ],
-    "fan_min_speed": [
-        "10"
-    ],
-    "slow_down_min_speed": [
-        "10"
-    ],
-    "slow_down_layer_time": [
-        "8"
-    ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "90"
     ],
     "nozzle_temperature": [
         "290"
     ],
+    "nozzle_temperature_initial_layer": [
+        "290"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
     "temperature_vitrification": [
         "70.4"
     ],
+    "textured_plate_temp": [
+        "50"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "50"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic PC-CF @Elegoo",
     "nozzle_temperature_range_low": [
         "280"
     ],
@@ -116,9 +135,6 @@
     ],
     "filament_id": "PMPA03",
     "setting_id": "GPCCF00",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "is_custom_defined": "0",
     "pressure_advance": [
         "0.1"

--- a/preset/Fiberon PA612-CF15/Elegoo/CC2/ElegooSlicer/Fiberon PA612-CF15 @Elegoo CC2.json
+++ b/preset/Fiberon PA612-CF15/Elegoo/CC2/ElegooSlicer/Fiberon PA612-CF15 @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PA612-CF15 @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "100"
-    ],
-    "hot_plate_temp": [
-        "100"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "100"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "100"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "60"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.93"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "100"
     ],
     "fan_cooling_layer_time": [
         "20"
+    ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "0"
     ],
     "filament_cost": [
         "20"
@@ -60,17 +48,17 @@
     "filament_diameter": [
         "1.75"
     ],
+    "filament_flow_ratio": [
+        "0.93"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
     "filament_max_volumetric_speed": [
         "16"
     ],
     "filament_minimal_purge_on_wipe_tower": [
         "15"
-    ],
-    "filament_retraction_length": [
-        "1.0"
-    ],
-    "filament_z_hop": [
-        "0.0"
     ],
     "filament_settings_id": [
         "Fiberon PA612-CF15 @Elegoo CC2"
@@ -84,48 +72,91 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "290"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "20"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "0"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "100"
     ],
     "nozzle_temperature": [
         "290"
     ],
+    "nozzle_temperature_initial_layer": [
+        "290"
+    ],
+    "overhang_fan_speed": [
+        "30"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "40"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "206.2"
+    ],
+    "textured_plate_temp": [
+        "50"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "50"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PA-CF @System",
+    "filament_id": "PMPA04",
+    "nozzle_temperature_range_high": [
+        "300"
     ],
     "nozzle_temperature_range_low": [
         "250"
     ],
-    "nozzle_temperature_range_high": [
-        "300"
-    ],
     "renamed_from": "My Generic PA-CF",
     "setting_id": "OGFSA04",
-    "filament_id": "PMPA04",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon PA612-ESD/Elegoo/CC2/ElegooSlicer/Fiberon PA612-ESD @Elegoo CC2.json
+++ b/preset/Fiberon PA612-ESD/Elegoo/CC2/ElegooSlicer/Fiberon PA612-ESD @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PA612-ESD @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "100"
-    ],
-    "hot_plate_temp": [
-        "100"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "100"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "100"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "10%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "60"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.85"
-    ],
-    "reduce_fan_stop_start_freq": [
+    "cool_plate_temp": [
         "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "100"
     ],
     "fan_cooling_layer_time": [
         "5"
+    ],
+    "fan_max_speed": [
+        "10"
+    ],
+    "fan_min_speed": [
+        "10"
     ],
     "filament_cost": [
         "20"
@@ -60,17 +48,17 @@
     "filament_diameter": [
         "1.75"
     ],
+    "filament_flow_ratio": [
+        "0.85"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
     "filament_max_volumetric_speed": [
         "16"
     ],
     "filament_minimal_purge_on_wipe_tower": [
         "15"
-    ],
-    "filament_retraction_length": [
-        "1.0"
-    ],
-    "filament_z_hop": [
-        "0.0"
     ],
     "filament_settings_id": [
         "Fiberon PA612-ESD @Elegoo CC2"
@@ -84,56 +72,69 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "290"
-    ],
     "full_fan_speed_layer": [
         "2"
     ],
-    "fan_max_speed": [
-        "10"
+    "hot_plate_temp": [
+        "100"
     ],
-    "fan_min_speed": [
-        "10"
-    ],
-    "slow_down_min_speed": [
-        "10"
-    ],
-    "slow_down_layer_time": [
-        "5"
-    ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "100"
     ],
     "nozzle_temperature": [
         "290"
     ],
-    "temperature_vitrification": [
-        "170"
+    "nozzle_temperature_initial_layer": [
+        "290"
     ],
-    "nozzle_temperature_range_low": [
-        "260"
+    "overhang_fan_speed": [
+        "100"
     ],
-    "nozzle_temperature_range_high": [
-        "300"
+    "overhang_fan_threshold": [
+        "10%"
     ],
-    "filament_id": "PMPA05",
-    "chamber_temperatures": [
-        "60"
+    "reduce_fan_stop_start_freq": [
+        "0"
     ],
     "required_nozzle_HRC": [
         "3"
     ],
-    "setting_id": "GPA6CF00",
-    "activate_air_filtration": [
-        "0"
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "170"
+    ],
+    "textured_plate_temp": [
+        "50"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "50"
     ],
     "compatible_printers": [
         "Elegoo Centauri Carbon 2 0.4 nozzle"
     ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic PA6-CF @Elegoo",
+    "nozzle_temperature_range_high": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "260"
+    ],
+    "filament_id": "PMPA05",
+    "setting_id": "GPA6CF00",
     "chamber_temperature": [
         "0"
     ],

--- a/preset/Fiberon PET-CF17/Elegoo/CC2/ElegooSlicer/Fiberon PET-CF17 @Elegoo CC2.json
+++ b/preset/Fiberon PET-CF17/Elegoo/CC2/ElegooSlicer/Fiberon PET-CF17 @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Fiberon PET-CF17 @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "70"
-    ],
-    "hot_plate_temp": [
-        "90"
-    ],
-    "textured_plate_temp": [
-        "90"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "70"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "90"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "90"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.94"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
     ],
     "fan_cooling_layer_time": [
         "31"
     ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
     "filament_cost": [
-        "0"
+        "30"
     ],
     "filament_density": [
         "1.34"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,56 +72,69 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "270"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "hot_plate_temp": [
+        "90"
     ],
-    "fan_min_speed": [
-        "10"
-    ],
-    "slow_down_min_speed": [
-        "20"
-    ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; Filament start gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "90"
     ],
     "nozzle_temperature": [
         "270"
     ],
+    "nozzle_temperature_initial_layer": [
+        "270"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "40"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
     "temperature_vitrification": [
         "79.3"
     ],
-    "filament_id": "PMPE01",
+    "textured_plate_temp": [
+        "90"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "90"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic PET-CF @Elegoo Centauri",
     "nozzle_temperature_range_high": [
         "300"
     ],
     "nozzle_temperature_range_low": [
         "270"
     ],
-    "supertack_plate_temp": [
-        "70"
-    ],
-    "supertack_plate_temp_initial_layer": [
-        "70"
-    ],
+    "filament_id": "PMPE01",
     "setting_id": "GPETCF00",
-    "required_nozzle_HRC": [
-        "40"
-    ],
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon PET-CF17/Snapmaker/U1/OrcaSlicer/Fiberon PET-CF17 @Snapmaker U1.json
+++ b/preset/Fiberon PET-CF17/Snapmaker/U1/OrcaSlicer/Fiberon PET-CF17 @Snapmaker U1.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PET-CF17 @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "70"
-    ],
-    "hot_plate_temp": [
-        "70"
-    ],
-    "textured_plate_temp": [
-        "70"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "70"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "70"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "70"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.93"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
     ],
     "fan_cooling_layer_time": [
         "30"
+    ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "0"
     ],
     "filament_cost": [
         "0"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.93"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "20"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "300"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "0"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "70"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "70"
     ],
     "nozzle_temperature": [
         "300"
     ],
-    "temperature_vitrification": [
-        "79.3"
-    ],
-    "filament_id": "PMPE01",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "300"
     ],
-    "nozzle_temperature_range_low": [
-        "270"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "40"
     ],
     "supertack_plate_temp": [
         "80"
@@ -121,13 +120,42 @@
     "supertack_plate_temp_initial_layer": [
         "80"
     ],
-    "required_nozzle_HRC": [
-        "40"
+    "slow_down_for_layer_cooling": [
+        "1"
     ],
-    "setting_id": "OGFSL54_00",
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "79.3"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Snapmaker U1 (0.4 nozzle)"
     ],
+    "inherits": "Fiberon PET-CF @System",
+    "filament_id": "PMPE01",
+    "nozzle_temperature_range_high": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "270"
+    ],
+    "setting_id": "OGFSL54_00",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon PET-GF15/BBL/H2D/BambuStudio/Fiberon PET-GF15 @BBL H2D.json
+++ b/preset/Fiberon PET-GF15/BBL/H2D/BambuStudio/Fiberon PET-GF15 @BBL H2D.json
@@ -3,38 +3,17 @@
     "name": "Fiberon PET-GF15 @BBL H2D",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "70"
-    ],
-    "hot_plate_temp": [
-        "70"
-    ],
-    "textured_plate_temp": [
-        "70"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "additional_cooling_fan_speed": [
         "0"
     ],
-    "eng_plate_temp_initial_layer": [
-        "70"
+    "chamber_temperatures": [
+        "0"
     ],
-    "hot_plate_temp_initial_layer": [
-        "70"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "70"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "circle_compensation_speed": [
+        "200"
     ],
     "close_fan_the_first_x_layers": [
         "3"
@@ -42,18 +21,78 @@
     "close_additional_fan_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.92",
-        "nil"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "counter_coef_1": [
+        "0"
+    ],
+    "counter_coef_2": [
+        "0.008"
+    ],
+    "counter_coef_3": [
+        "-0.041"
+    ],
+    "counter_limit_max": [
+        "0.033"
+    ],
+    "counter_limit_min": [
+        "-0.035"
+    ],
+    "diameter_limit": [
+        "50"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
     ],
     "fan_cooling_layer_time": [
         "25"
+    ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "filament_adaptive_volumetric_speed": [
+        "0"
+    ],
+    "filament_extruder_compatibility": [
+        "0"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_preheat_temperature_delta": [
+        "0"
+    ],
+    "filament_tower_interface_pre_extrusion_dist": [
+        "10"
+    ],
+    "filament_tower_interface_pre_extrusion_length": [
+        "0"
+    ],
+    "filament_tower_ironing_area": [
+        "4"
+    ],
+    "filament_tower_interface_purge_volume": [
+        "20"
+    ],
+    "filament_tower_interface_print_temp": [
+        "-1"
     ],
     "filament_cost": [
         "89.99"
@@ -61,21 +100,102 @@
     "filament_density": [
         "1.43"
     ],
+    "filament_dev_ams_drying_ams_limitations": [
+        "1"
+    ],
+    "filament_dev_ams_drying_heat_distortion_temperature": [
+        "165"
+    ],
+    "filament_dev_ams_drying_temperature": [
+        "65",
+        "80",
+        "65",
+        "80"
+    ],
+    "filament_dev_ams_drying_time": [
+        "12",
+        "12",
+        "12",
+        "12"
+    ],
+    "filament_dev_chamber_drying_bed_temperature": [
+        "90"
+    ],
+    "filament_dev_chamber_drying_time": [
+        "12.0"
+    ],
+    "filament_dev_drying_cooling_temperature": [
+        "150"
+    ],
+    "filament_dev_drying_softening_temperature": [
+        "150"
+    ],
     "filament_diameter": [
         "1.75"
     ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
+    ],
+    "filament_flow_ratio": [
+        "0.92",
+        "nil"
+    ],
+    "filament_flush_temp": [
+        "0"
+    ],
+    "filament_flush_volumetric_speed": [
+        "0"
+    ],
     "filament_is_support": [
         "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1",
+        "1"
     ],
     "filament_max_volumetric_speed": [
         "16",
         "nil"
     ],
+    "filament_metal_stickiness": [
+        "High"
+    ],
     "filament_minimal_purge_on_wipe_tower": [
         "15"
     ],
+    "filament_pre_cooling_temperature": [
+        "0"
+    ],
+    "filament_pre_cooling_temperature_nc": [
+        "0"
+    ],
+    "filament_prime_volume": [
+        "45"
+    ],
+    "filament_prime_volume_nc": [
+        "60"
+    ],
+    "filament_printable": [
+        "3"
+    ],
+    "filament_ramming_travel_time_nc": [
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1"
+    ],
+    "filament_ramming_volumetric_speed_nc": [
+        "-1"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
     "filament_settings_id": [
         "Fiberon PET-GF15 @BBL H2D"
+    ],
+    "filament_shrink": [
+        "100%"
     ],
     "filament_soluble": [
         "0"
@@ -86,75 +206,137 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280",
-        "nil"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
     "additional_fan_full_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "fan_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
         "0"
     ],
-    "required_nozzle_HRC": [
-        "40"
+    "filament_retract_length_nc": [
+        "14"
     ],
-    "slow_down_min_speed": [
-        "20",
-        "20"
+    "filament_enable_overhang_speed": [
+        "1"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_overhang_1_4_speed": [
+        "0"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    "filament_overhang_2_4_speed": [
+        "50"
+    ],
+    "filament_overhang_3_4_speed": [
+        "30"
+    ],
+    "filament_overhang_4_4_speed": [
+        "10"
+    ],
+    "filament_overhang_totally_speed": [
+        "10"
+    ],
+    "filament_bridge_speed": [
+        "25"
+    ],
+    "filament_change_length": [
+        "10"
+    ],
+    "filament_velocity_adaptation_factor": [
+        "1"
+    ],
+    "hot_plate_temp": [
+        "70"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "70"
+    ],
+    "filament_ingredients_safe": "1",
+    "filament_emission_safe": "1",
+    "filament_contact_safe": "1",
+    "hole_coef_1": [
+        "0"
+    ],
+    "hole_coef_2": [
+        "-0.008"
+    ],
+    "hole_coef_3": [
+        "0.23415"
+    ],
+    "hole_limit_max": [
+        "0.22"
+    ],
+    "hole_limit_min": [
+        "0.088"
+    ],
+    "impact_strength_z": [
+        "10"
+    ],
+    "long_retractions_when_ec": [
+        "0",
+        "0"
+    ],
+    "no_slow_down_for_cooling_on_outwalls": [
+        "0"
     ],
     "nozzle_temperature": [
         "280",
         "nil"
     ],
-    "temperature_vitrification": [
-        "232.6"
-    ],
-    "nozzle_temperature_range_low": [
-        "280"
+    "nozzle_temperature_initial_layer": [
+        "280",
+        "nil"
     ],
     "nozzle_temperature_range_high": [
         "310"
     ],
-    "filament_id": "PMPE08",
-    "filament_adhesiveness_category": [
-        "800"
+    "nozzle_temperature_range_low": [
+        "280"
     ],
-    "filament_dev_chamber_drying_bed_temperature": [
-        "90"
+    "overhang_fan_speed": [
+        "100"
     ],
-    "filament_dev_ams_drying_ams_limitations": [
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "override_process_overhang_speed": [
+        "0"
+    ],
+    "reduce_fan_stop_start_freq": [
         "1"
     ],
-    "filament_dev_ams_drying_heat_distortion_temperature": [
-        "165"
+    "required_nozzle_HRC": [
+        "40"
     ],
-    "filament_dev_drying_cooling_temperature": [
-        "150"
+    "retraction_distances_when_ec": [
+        "0",
+        "0"
     ],
-    "filament_dev_ams_drying_temperature": [
-        "65",
-        "80",
-        "65",
-        "80"
+    "slow_down_for_layer_cooling": [
+        "1"
     ],
-    "filament_dev_drying_softening_temperature": [
-        "150"
+    "cooling_slowdown_logic": [
+        "uniform_cooling"
+    ],
+    "cooling_perimeter_transition_distance": [
+        "10"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
     ],
     "supertack_plate_temp": [
         "70"
@@ -162,36 +344,35 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "setting_id": "GFL54_10",
-    "filament_cooling_before_tower": [
-        "10",
-        "10"
+    "temperature_vitrification": [
+        "232.6"
     ],
-    "filament_long_retractions_when_cut": [
-        "1",
-        "1"
+    "textured_plate_temp": [
+        "70"
     ],
-    "filament_ramming_travel_time": [
-        "0",
-        "0"
+    "textured_plate_temp_initial_layer": [
+        "70"
     ],
-    "include": [
-        "fdm_filament_template_direct_dual"
-    ],
-    "long_retractions_when_ec": [
-        "0",
-        "0"
-    ],
-    "retraction_distances_when_ec": [
-        "0",
-        "0"
+    "volumetric_speed_coefficients": [
+        "0 0 0 0 0 0"
     ],
     "compatible_printers": [
         "Bambu Lab H2D 0.4 nozzle"
     ],
-    "filament_extruder_variant": [
-        "Direct Drive Standard",
-        "Direct Drive High Flow"
+    "filament_start_gcode": [
+        "; filament start gcode\n{if (bed_temperature[current_extruder] >80)||(bed_temperature_initial_layer[current_extruder] >80)}M106 P3 S255\n{elsif (bed_temperature[current_extruder] >60)||(bed_temperature_initial_layer[current_extruder] >60)}M106 P3 S180\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n\n"
+    ],
+    "inherits": "Fiberon PET-CF @BBL H2D",
+    "filament_adhesiveness_category": [
+        "800"
+    ],
+    "filament_id": "PMPE08",
+    "setting_id": "GFL54_10",
+    "include": [
+        "fdm_filament_template_direct_dual"
     ],
     "version": "2.6.0.5",
     "idle_temperature": [

--- a/preset/Fiberon PET-GF15/Elegoo/CC2/ElegooSlicer/Fiberon PET-GF15 @Elegoo CC2.json
+++ b/preset/Fiberon PET-GF15/Elegoo/CC2/ElegooSlicer/Fiberon PET-GF15 @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Fiberon PET-GF15 @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "70"
-    ],
-    "hot_plate_temp": [
-        "90"
-    ],
-    "textured_plate_temp": [
-        "70"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "70"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "90"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "70"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.94"
-    ],
-    "reduce_fan_stop_start_freq": [
+    "cool_plate_temp": [
         "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
     ],
     "fan_cooling_layer_time": [
         "25"
     ],
-    "filament_cost": [
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
         "0"
+    ],
+    "filament_cost": [
+        "30"
     ],
     "filament_density": [
         "1.43"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -78,56 +72,69 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "300"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "hot_plate_temp": [
+        "90"
     ],
-    "fan_min_speed": [
-        "0"
-    ],
-    "slow_down_min_speed": [
-        "20"
-    ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; Filament start gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "90"
     ],
     "nozzle_temperature": [
         "300"
     ],
+    "nozzle_temperature_initial_layer": [
+        "300"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "0"
+    ],
+    "required_nozzle_HRC": [
+        "40"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
     "temperature_vitrification": [
         "232.6"
     ],
-    "filament_id": "PMPE08",
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic PET-CF @Elegoo Centauri",
     "nozzle_temperature_range_high": [
         "310"
     ],
     "nozzle_temperature_range_low": [
         "280"
     ],
-    "supertack_plate_temp": [
-        "70"
-    ],
-    "supertack_plate_temp_initial_layer": [
-        "70"
-    ],
+    "filament_id": "PMPE08",
     "setting_id": "GPETCF00",
-    "required_nozzle_HRC": [
-        "40"
-    ],
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon PET-GF15/Snapmaker/U1/OrcaSlicer/Fiberon PET-GF15 @Snapmaker U1.json
+++ b/preset/Fiberon PET-GF15/Snapmaker/U1/OrcaSlicer/Fiberon PET-GF15 @Snapmaker U1.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PET-GF15 @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "eng_plate_temp": [
-        "70"
-    ],
-    "hot_plate_temp": [
-        "70"
-    ],
-    "textured_plate_temp": [
-        "70"
-    ],
-    "cool_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "70"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "70"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "70"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.88"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "70"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "70"
     ],
     "fan_cooling_layer_time": [
         "30"
+    ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "0"
     ],
     "filament_cost": [
         "0"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.88"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "300"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "0"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "70"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "70"
     ],
     "nozzle_temperature": [
         "300"
     ],
-    "temperature_vitrification": [
-        "232.6"
-    ],
-    "filament_id": "PMPE08",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "300"
     ],
-    "nozzle_temperature_range_low": [
-        "280"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "40"
     ],
     "supertack_plate_temp": [
         "80"
@@ -121,13 +120,42 @@
     "supertack_plate_temp_initial_layer": [
         "80"
     ],
-    "required_nozzle_HRC": [
-        "40"
+    "slow_down_for_layer_cooling": [
+        "1"
     ],
-    "setting_id": "OGFSL54_00",
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "232.6"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Snapmaker U1 (0.4 nozzle)"
     ],
+    "inherits": "Fiberon PET-CF @System",
+    "filament_id": "PMPE08",
+    "nozzle_temperature_range_high": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "280"
+    ],
+    "setting_id": "OGFSL54_00",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon PETG-ESD/Elegoo/CC2/ElegooSlicer/Fiberon PETG-ESD @Elegoo CC2.json
+++ b/preset/Fiberon PETG-ESD/Elegoo/CC2/ElegooSlicer/Fiberon PETG-ESD @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PETG-ESD @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.94"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "25"
+    ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "0"
     ],
     "filament_cost": [
         "30"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "290"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "20"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "0"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "290"
     ],
-    "temperature_vitrification": [
-        "77"
-    ],
-    "filament_id": "PMPE02",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "290"
     ],
-    "nozzle_temperature_range_low": [
-        "250"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "77"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Elegoo Centauri Carbon 2 0.4 nozzle"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE02",
+    "nozzle_temperature_range_high": [
+        "290"
+    ],
+    "nozzle_temperature_range_low": [
+        "250"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Fiberon PETG-ESD/Snapmaker/U1/OrcaSlicer/Fiberon PETG-ESD @Snapmaker U1.json
+++ b/preset/Fiberon PETG-ESD/Snapmaker/U1/OrcaSlicer/Fiberon PETG-ESD @Snapmaker U1.json
@@ -3,53 +3,41 @@
     "name": "Fiberon PETG-ESD @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.95"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "31"
+    ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "10"
     ],
     "filament_cost": [
         "30"
@@ -60,8 +48,14 @@
     "filament_diameter": [
         "1.75"
     ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
     "filament_max_volumetric_speed": [
-        "12"
+        "10"
     ],
     "filament_minimal_purge_on_wipe_tower": [
         "15"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "20"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_min_speed": [
-        "10"
+    "filament_shrink": [
+        "100%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "hot_plate_temp": [
+        "80"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "280"
     ],
-    "temperature_vitrification": [
-        "77"
+    "nozzle_temperature_initial_layer": [
+        "280"
     ],
-    "filament_id": "PMPE02",
-    "nozzle_temperature_range_high": [
-        "290"
+    "overhang_fan_speed": [
+        "100"
     ],
-    "nozzle_temperature_range_low": [
-        "250"
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "77"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Snapmaker U1 (0.4 nozzle)"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE02",
+    "nozzle_temperature_range_high": [
+        "290"
+    ],
+    "nozzle_temperature_range_low": [
+        "250"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Panchroma CoPE/Elegoo/CC2/ElegooSlicer/Panchroma CoPE @Elegoo CC2.json
+++ b/preset/Panchroma CoPE/Elegoo/CC2/ElegooSlicer/Panchroma CoPE @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma CoPE @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.29"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "58.2"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMCO01",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "200"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMCO01"
+    ]
 }

--- a/preset/Panchroma PLA Celestial/Elegoo/CC2/ElegooSlicer/Panchroma PLA Celestial @Elegoo CC2.json
+++ b/preset/Panchroma PLA Celestial/Elegoo/CC2/ElegooSlicer/Panchroma PLA Celestial @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Celestial @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL02",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL02"
+    ]
 }

--- a/preset/Panchroma PLA Galaxy/Elegoo/CC2/ElegooSlicer/Panchroma PLA Galaxy @Elegoo CC2.json
+++ b/preset/Panchroma PLA Galaxy/Elegoo/CC2/ElegooSlicer/Panchroma PLA Galaxy @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Galaxy @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL03",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL03"
+    ]
 }

--- a/preset/Panchroma PLA Glow/Elegoo/CC2/ElegooSlicer/Panchroma PLA Glow @Elegoo CC2.json
+++ b/preset/Panchroma PLA Glow/Elegoo/CC2/ElegooSlicer/Panchroma PLA Glow @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Glow @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL04",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL04"
+    ]
 }

--- a/preset/Panchroma PLA Luminous/Elegoo/CC2/ElegooSlicer/Panchroma PLA Luminous @Elegoo CC2.json
+++ b/preset/Panchroma PLA Luminous/Elegoo/CC2/ElegooSlicer/Panchroma PLA Luminous @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Luminous @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL05",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL05"
+    ]
 }

--- a/preset/Panchroma PLA Marble/Elegoo/CC2/ElegooSlicer/Panchroma PLA Marble @Elegoo CC2.json
+++ b/preset/Panchroma PLA Marble/Elegoo/CC2/ElegooSlicer/Panchroma PLA Marble @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Marble @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.01"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.37"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.01"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL06",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL06"
+    ]
 }

--- a/preset/Panchroma PLA Matte/Elegoo/CC2/ElegooSlicer/Panchroma PLA Matte @Elegoo CC2.json
+++ b/preset/Panchroma PLA Matte/Elegoo/CC2/ElegooSlicer/Panchroma PLA Matte @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Matte @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.01"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.37"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.01"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL07",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL07"
+    ]
 }

--- a/preset/Panchroma PLA Metallic/Elegoo/CC2/ElegooSlicer/Panchroma PLA Metallic @Elegoo CC2.json
+++ b/preset/Panchroma PLA Metallic/Elegoo/CC2/ElegooSlicer/Panchroma PLA Metallic @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Metallic @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL08",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL08"
+    ]
 }

--- a/preset/Panchroma PLA Neon/Elegoo/CC2/ElegooSlicer/Panchroma PLA Neon @Elegoo CC2.json
+++ b/preset/Panchroma PLA Neon/Elegoo/CC2/ElegooSlicer/Panchroma PLA Neon @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Neon @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL09",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL09"
+    ]
 }

--- a/preset/Panchroma PLA Satin/Elegoo/CC2/ElegooSlicer/Panchroma PLA Satin @Elegoo CC2.json
+++ b/preset/Panchroma PLA Satin/Elegoo/CC2/ElegooSlicer/Panchroma PLA Satin @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Satin @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.02"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.24"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.02"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "59"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL10",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL10"
+    ]
 }

--- a/preset/Panchroma PLA Silk/Elegoo/CC2/ElegooSlicer/Panchroma PLA Silk @Elegoo CC2.json
+++ b/preset/Panchroma PLA Silk/Elegoo/CC2/ElegooSlicer/Panchroma PLA Silk @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Silk @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.92"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
         "100"
     ],
     "filament_cost": [
-        "0"
+        "20"
     ],
     "filament_density": [
         "1.34"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.92"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "11.5"
@@ -78,36 +72,61 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "230"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "hot_plate_temp": [
+        "60"
     ],
-    "fan_min_speed": [
-        "100"
-    ],
-    "slow_down_min_speed": [
-        "5"
-    ],
-    "slow_down_layer_time": [
-        "4"
-    ],
-    "filament_start_gcode": [
-        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    "hot_plate_temp_initial_layer": [
+        "60"
     ],
     "nozzle_temperature": [
         "230"
     ],
+    "nozzle_temperature_initial_layer": [
+        "230"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
     "temperature_vitrification": [
         "58.2"
     ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if  (bed_temperature[current_extruder] >55)||(bed_temperature_initial_layer[current_extruder] >55)}M106 P3 S200\n{elsif(bed_temperature[current_extruder] >50)||(bed_temperature_initial_layer[current_extruder] >50)}M106 P3 S150\n{elsif(bed_temperature[current_extruder] >45)||(bed_temperature_initial_layer[current_extruder] >45)}M106 P3 S50\n{endif}\n\n{if activate_air_filtration[current_extruder] && support_air_filtration}\nM106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]} \n{endif}"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic PLA @Elegoo Centauri",
     "nozzle_temperature_range_low": [
         "190"
     ],
@@ -121,9 +140,6 @@
     "setting_id": "GPLA00",
     "pressure_advance": [
         "0.024"
-    ],
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
     ],
     "is_custom_defined": "0",
     "version": "1.3.0.11",

--- a/preset/Panchroma PLA Starlight/Elegoo/CC2/ElegooSlicer/Panchroma PLA Starlight @Elegoo CC2.json
+++ b/preset/Panchroma PLA Starlight/Elegoo/CC2/ElegooSlicer/Panchroma PLA Starlight @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Starlight @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL12",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL12"
+    ]
 }

--- a/preset/Panchroma PLA Translucent/Elegoo/CC2/ElegooSlicer/Panchroma PLA Translucent @Elegoo CC2.json
+++ b/preset/Panchroma PLA Translucent/Elegoo/CC2/ElegooSlicer/Panchroma PLA Translucent @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA Translucent @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL13",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL13"
+    ]
 }

--- a/preset/Panchroma PLA UV Shift/Elegoo/CC2/ElegooSlicer/Panchroma PLA UV Shift @Elegoo CC2.json
+++ b/preset/Panchroma PLA UV Shift/Elegoo/CC2/ElegooSlicer/Panchroma PLA UV Shift @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA UV Shift @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL14",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL14"
+    ]
 }

--- a/preset/Panchroma PLA/Anycubic/Kobra S1/OrcaSlicer/Panchroma PLA @Anycubic Kobra S1.json
+++ b/preset/Panchroma PLA/Anycubic/Kobra S1/OrcaSlicer/Panchroma PLA @Anycubic Kobra S1.json
@@ -3,52 +3,40 @@
     "name": "Panchroma PLA @Anycubic Kobra S1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.88"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
         "100"
     ],
     "filament_cost": [
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.88"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "20"
@@ -78,35 +72,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
+    "filament_scarf_length": [
         "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "62.5"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Anycubic Kobra S1 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA @System",
+    "filament_id": "PMPL01",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -114,14 +158,8 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic PLA",
     "setting_id": "OGFSA04",
-    "compatible_printers": [
-        "Anycubic Kobra S1 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -129,6 +167,5 @@
     "version": "2.3.1.10",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL01"
+    ]
 }

--- a/preset/Panchroma PLA/Elegoo/CC2/ElegooSlicer/Panchroma PLA @Elegoo CC2.json
+++ b/preset/Panchroma PLA/Elegoo/CC2/ElegooSlicer/Panchroma PLA @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Panchroma PLA @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.97"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.32"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.97"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "20"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "62.5"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL01",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL01"
+    ]
 }

--- a/preset/PolyFlex TPU95/Elegoo/CC2/ElegooSlicer/PolyFlex TPU95 @Elegoo CC2.json
+++ b/preset/PolyFlex TPU95/Elegoo/CC2/ElegooSlicer/PolyFlex TPU95 @Elegoo CC2.json
@@ -1,0 +1,177 @@
+{
+    "type": "filament",
+    "name": "PolyFlex TPU95 @Elegoo CC2",
+    "from": "User",
+    "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "30"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "30"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "30"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "30"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.2"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.05"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "4"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_retraction_length": [
+        "1.4"
+    ],
+    "filament_settings_id": [
+        "PolyFlex TPU95 @Elegoo CC2"
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "35"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "35"
+    ],
+    "nozzle_temperature": [
+        "230"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "230"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "0"
+    ],
+    "textured_plate_temp": [
+        "35"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "35"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic TPU @System",
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "nozzle_temperature_range_high": [
+        "230"
+    ],
+    "nozzle_temperature_range_low": [
+        "210"
+    ],
+    "renamed_from": "My Generic TPU",
+    "setting_id": "OGFSA04",
+    "filament_id": "PMTP01",
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "is_custom_defined": "0",
+    "pressure_advance": [
+        "0.2"
+    ],
+    "version": "1.5.2.2",
+    "idle_temperature": [
+        "0"
+    ]
+}

--- a/preset/PolyLite CosPLA/Elegoo/CC2/ElegooSlicer/PolyLite CosPLA @Elegoo CC2.json
+++ b/preset/PolyLite CosPLA/Elegoo/CC2/ElegooSlicer/PolyLite CosPLA @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite CosPLA @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.02"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.24"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.02"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "59"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMCO02",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMCO02"
+    ]
 }

--- a/preset/PolyLite PETG Translucent/Elegoo/CC2/ElegooSlicer/PolyLite PETG Translucent @Elegoo CC2.json
+++ b/preset/PolyLite PETG Translucent/Elegoo/CC2/ElegooSlicer/PolyLite PETG Translucent @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "PolyLite PETG Translucent @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "0%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.03"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "30"
+    ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "10"
     ],
     "filament_cost": [
         "30"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.03"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "260"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "20"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_min_speed": [
-        "10"
+    "filament_shrink": [
+        "100%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "hot_plate_temp": [
+        "80"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "260"
     ],
-    "temperature_vitrification": [
-        "81"
-    ],
-    "filament_id": "PMPE05",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "nozzle_temperature_range_low": [
-        "230"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "0%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "81"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Elegoo Centauri Carbon 2 0.4 nozzle"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE05",
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "230"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/PolyLite PETG Translucent/Snapmaker/U1/OrcaSlicer/PolyLite PETG Translucent @Snapmaker U1.json
+++ b/preset/PolyLite PETG Translucent/Snapmaker/U1/OrcaSlicer/PolyLite PETG Translucent @Snapmaker U1.json
@@ -3,53 +3,41 @@
     "name": "PolyLite PETG Translucent @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.92"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "20"
+    ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "0"
     ],
     "filament_cost": [
         "0"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.92"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "7.5"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "260"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "0"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "260"
     ],
-    "temperature_vitrification": [
-        "81"
-    ],
-    "filament_id": "PMPE05",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "nozzle_temperature_range_low": [
-        "230"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "81"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Snapmaker U1 (0.4 nozzle)"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE05",
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "230"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/PolyLite PETG/Elegoo/CC2/ElegooSlicer/PolyLite PETG @Elegoo CC2.json
+++ b/preset/PolyLite PETG/Elegoo/CC2/ElegooSlicer/PolyLite PETG @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "PolyLite PETG @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "0%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.03"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "30"
+    ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "10"
     ],
     "filament_cost": [
         "30"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.03"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "260"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "20"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_min_speed": [
-        "10"
+    "filament_shrink": [
+        "100%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "hot_plate_temp": [
+        "80"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "260"
     ],
-    "temperature_vitrification": [
-        "81"
-    ],
-    "filament_id": "PMPE04",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "nozzle_temperature_range_low": [
-        "230"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "0%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "81"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Elegoo Centauri Carbon 2 0.4 nozzle"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE04",
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "230"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/PolyLite PETG/Snapmaker/U1/OrcaSlicer/PolyLite PETG @Snapmaker U1.json
+++ b/preset/PolyLite PETG/Snapmaker/U1/OrcaSlicer/PolyLite PETG @Snapmaker U1.json
@@ -3,53 +3,41 @@
     "name": "PolyLite PETG @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.92"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "20"
+    ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "0"
     ],
     "filament_cost": [
         "0"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.92"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "7.5"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "260"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "0"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "260"
     ],
-    "temperature_vitrification": [
-        "81"
-    ],
-    "filament_id": "PMPE04",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "nozzle_temperature_range_low": [
-        "230"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "81"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Snapmaker U1 (0.4 nozzle)"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE04",
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "230"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/PolyLite PLA Galaxy/Elegoo/CC2/ElegooSlicer/PolyLite PLA Galaxy @Elegoo CC2.json
+++ b/preset/PolyLite PLA Galaxy/Elegoo/CC2/ElegooSlicer/PolyLite PLA Galaxy @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite PLA Galaxy @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL16",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL16"
+    ]
 }

--- a/preset/PolyLite PLA Glow/Elegoo/CC2/ElegooSlicer/PolyLite PLA Glow @Elegoo CC2.json
+++ b/preset/PolyLite PLA Glow/Elegoo/CC2/ElegooSlicer/PolyLite PLA Glow @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite PLA Glow @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL17",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL17"
+    ]
 }

--- a/preset/PolyLite PLA Luminous/Elegoo/CC2/ElegooSlicer/PolyLite PLA Luminous @Elegoo CC2.json
+++ b/preset/PolyLite PLA Luminous/Elegoo/CC2/ElegooSlicer/PolyLite PLA Luminous @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite PLA Luminous @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL18",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL18"
+    ]
 }

--- a/preset/PolyLite PLA Neon/Elegoo/CC2/ElegooSlicer/PolyLite PLA Neon @Elegoo CC2.json
+++ b/preset/PolyLite PLA Neon/Elegoo/CC2/ElegooSlicer/PolyLite PLA Neon @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite PLA Neon @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL19",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL19"
+    ]
 }

--- a/preset/PolyLite PLA Pro Metallic/Elegoo/CC2/ElegooSlicer/PolyLite PLA Pro Metallic @Elegoo CC2.json
+++ b/preset/PolyLite PLA Pro Metallic/Elegoo/CC2/ElegooSlicer/PolyLite PLA Pro Metallic @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite PLA Pro Metallic @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.95"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.22"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "62"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL21",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "is_custom_defined": "0",
     "pressure_advance": [
         "0.05"
@@ -131,6 +169,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL21"
+    ]
 }

--- a/preset/PolyLite PLA Pro/Elegoo/CC2/ElegooSlicer/PolyLite PLA Pro @Elegoo CC2.json
+++ b/preset/PolyLite PLA Pro/Elegoo/CC2/ElegooSlicer/PolyLite PLA Pro @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite PLA Pro @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.95"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.22"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "62"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL20",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "is_custom_defined": "0",
     "pressure_advance": [
         "0.05"
@@ -131,6 +169,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL20"
+    ]
 }

--- a/preset/PolyLite PLA Starlight/Elegoo/CC2/ElegooSlicer/PolyLite PLA Starlight @Elegoo CC2.json
+++ b/preset/PolyLite PLA Starlight/Elegoo/CC2/ElegooSlicer/PolyLite PLA Starlight @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite PLA Starlight @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL22",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL22"
+    ]
 }

--- a/preset/PolyLite PLA Translucent/Elegoo/CC2/ElegooSlicer/PolyLite PLA Translucent @Elegoo CC2.json
+++ b/preset/PolyLite PLA Translucent/Elegoo/CC2/ElegooSlicer/PolyLite PLA Translucent @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite PLA Translucent @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL23",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL23"
+    ]
 }

--- a/preset/PolyLite PLA/Elegoo/CC2/ElegooSlicer/PolyLite PLA @Elegoo CC2.json
+++ b/preset/PolyLite PLA/Elegoo/CC2/ElegooSlicer/PolyLite PLA @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyLite PLA @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.17"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL15",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL15"
+    ]
 }

--- a/preset/PolyMax PC/BBL/X2D/BambuStudio/PolyMax PC @BBL X2D.json
+++ b/preset/PolyMax PC/BBL/X2D/BambuStudio/PolyMax PC @BBL X2D.json
@@ -76,6 +76,8 @@
         "10",
         "10",
         "10",
+        "10",
+        "10",
         "10"
     ],
     "filament_preheat_temperature_delta": [
@@ -97,7 +99,7 @@
         "280"
     ],
     "filament_cost": [
-        "39.99"
+        "36.99"
     ],
     "filament_density": [
         "1.19"
@@ -150,9 +152,6 @@
     "filament_flush_temp": [
         "0"
     ],
-    "filament_flush_temp_fast": [
-        "0"
-    ],
     "filament_flush_volumetric_speed": [
         "0"
     ],
@@ -195,12 +194,6 @@
     "filament_ramming_volumetric_speed_nc": [
         "-1"
     ],
-    "filament_retraction_length": [
-        "0.4",
-        "0.4",
-        "nil",
-        "nil"
-    ],
     "filament_scarf_seam_type": [
         "none"
     ],
@@ -219,24 +212,6 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "filament_wipe": [
-        "1",
-        "1",
-        "1",
-        "1"
-    ],
-    "filament_wipe_distance": [
-        "1",
-        "1",
-        "1",
-        "1"
-    ],
-    "filament_z_hop_types": [
-        "Spiral Lift",
-        "Spiral Lift",
-        "Spiral Lift",
-        "Spiral Lift"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
@@ -253,6 +228,8 @@
         "10"
     ],
     "filament_ramming_travel_time": [
+        "0",
+        "0",
         "0",
         "0",
         "0",
@@ -331,6 +308,8 @@
         "270",
         "270",
         "270",
+        "270",
+        "270",
         "270"
     ],
     "nozzle_temperature_range_high": [
@@ -340,7 +319,7 @@
         "250"
     ],
     "overhang_fan_speed": [
-        "75"
+        "60"
     ],
     "overhang_fan_threshold": [
         "25%"
@@ -357,6 +336,8 @@
     "retraction_distances_when_ec": [
         "3",
         "3",
+        "3",
+        "4",
         "4",
         "4"
     ],
@@ -376,6 +357,8 @@
         "20",
         "20",
         "20",
+        "20",
+        "20",
         "20"
     ],
     "supertack_plate_temp": [
@@ -385,7 +368,7 @@
         "0"
     ],
     "temperature_vitrification": [
-        "113"
+        "117"
     ],
     "textured_plate_temp": [
         "110"
@@ -405,13 +388,14 @@
     "filament_end_gcode": [
         "; filament end gcode \n\n"
     ],
+    "inherits": "Bambu PC @BBL X2D 0.4 nozzle",
     "filament_adhesiveness_category": [
         "500"
     ],
     "filament_id": "PMPC02",
     "setting_id": "GFSC00_18",
     "include": [
-        "fdm_filament_template_direct_bowden"
+        "fdm_filament_template_direct_bowden_e3d"
     ],
     "version": "2.6.0.2",
     "idle_temperature": [

--- a/preset/PolyMax PC/Elegoo/CC2/ElegooSlicer/PolyMax PC @Elegoo CC2.json
+++ b/preset/PolyMax PC/Elegoo/CC2/ElegooSlicer/PolyMax PC @Elegoo CC2.json
@@ -1,0 +1,149 @@
+{
+    "type": "filament",
+    "name": "PolyMax PC @Elegoo CC2",
+    "from": "User",
+    "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "110"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "110"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.19"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "4"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_settings_id": [
+        "PolyMax PC @Elegoo CC2"
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "PC"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "hot_plate_temp": [
+        "110"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "110"
+    ],
+    "nozzle_temperature": [
+        "270"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "270"
+    ],
+    "overhang_fan_speed": [
+        "50"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
+    "temperature_vitrification": [
+        "117"
+    ],
+    "textured_plate_temp": [
+        "110"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "110"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic PC @Elegoo",
+    "nozzle_temperature_range_low": [
+        "250"
+    ],
+    "nozzle_temperature_range_high": [
+        "270"
+    ],
+    "filament_id": "PMPC02",
+    "setting_id": "GPC00",
+    "additional_cooling_fan_speed": [
+        "100"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "is_custom_defined": "0",
+    "version": "1.5.2.2",
+    "idle_temperature": [
+        "0"
+    ]
+}

--- a/preset/PolyMax PETG/BBL/A2L/BambuStudio/PolyMax PETG @BBL A2L.json
+++ b/preset/PolyMax PETG/BBL/A2L/BambuStudio/PolyMax PETG @BBL A2L.json
@@ -1,0 +1,368 @@
+{
+    "type": "filament",
+    "name": "PolyMax PETG @BBL A2L",
+    "from": "User",
+    "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "additional_cooling_fan_speed": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "circle_compensation_speed": [
+        "200"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "close_additional_fan_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "counter_coef_1": [
+        "0"
+    ],
+    "counter_coef_2": [
+        "0.008"
+    ],
+    "counter_coef_3": [
+        "-0.041"
+    ],
+    "counter_limit_max": [
+        "0.033"
+    ],
+    "counter_limit_min": [
+        "-0.035"
+    ],
+    "diameter_limit": [
+        "50"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "80"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "80"
+    ],
+    "fan_cooling_layer_time": [
+        "22"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_adaptive_volumetric_speed": [
+        "0"
+    ],
+    "filament_extruder_compatibility": [
+        "0"
+    ],
+    "filament_cooling_before_tower": [
+        "0"
+    ],
+    "filament_preheat_temperature_delta": [
+        "0"
+    ],
+    "filament_tower_interface_pre_extrusion_dist": [
+        "10"
+    ],
+    "filament_tower_interface_pre_extrusion_length": [
+        "0"
+    ],
+    "filament_tower_ironing_area": [
+        "4"
+    ],
+    "filament_tower_interface_purge_volume": [
+        "20"
+    ],
+    "filament_tower_interface_print_temp": [
+        "-1"
+    ],
+    "filament_cost": [
+        "30"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_dev_ams_drying_ams_limitations": [
+        "1",
+        "0"
+    ],
+    "filament_dev_ams_drying_heat_distortion_temperature": [
+        "75"
+    ],
+    "filament_dev_ams_drying_temperature": [
+        "65",
+        "65",
+        "55",
+        "55"
+    ],
+    "filament_dev_ams_drying_time": [
+        "12",
+        "12",
+        "12",
+        "12"
+    ],
+    "filament_dev_chamber_drying_bed_temperature": [
+        "80"
+    ],
+    "filament_dev_chamber_drying_time": [
+        "12.0"
+    ],
+    "filament_dev_drying_cooling_temperature": [
+        "55"
+    ],
+    "filament_dev_drying_softening_temperature": [
+        "60"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_flush_temp": [
+        "0"
+    ],
+    "filament_flush_volumetric_speed": [
+        "0"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "4"
+    ],
+    "filament_metal_stickiness": [
+        "High"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0"
+    ],
+    "filament_pre_cooling_temperature_nc": [
+        "0"
+    ],
+    "filament_prime_volume": [
+        "45"
+    ],
+    "filament_prime_volume_nc": [
+        "60"
+    ],
+    "filament_printable": [
+        "3"
+    ],
+    "filament_ramming_travel_time_nc": [
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1"
+    ],
+    "filament_ramming_volumetric_speed_nc": [
+        "-1"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_settings_id": [
+        "PolyMax PETG @BBL A2L"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "additional_fan_full_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_ramming_travel_time": [
+        "0"
+    ],
+    "filament_retract_length_nc": [
+        "14"
+    ],
+    "filament_enable_overhang_speed": [
+        "1"
+    ],
+    "filament_overhang_1_4_speed": [
+        "0"
+    ],
+    "filament_overhang_2_4_speed": [
+        "50"
+    ],
+    "filament_overhang_3_4_speed": [
+        "30"
+    ],
+    "filament_overhang_4_4_speed": [
+        "10"
+    ],
+    "filament_overhang_totally_speed": [
+        "10"
+    ],
+    "filament_bridge_speed": [
+        "25"
+    ],
+    "filament_change_length": [
+        "10"
+    ],
+    "filament_velocity_adaptation_factor": [
+        "1"
+    ],
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_ingredients_safe": "1",
+    "filament_emission_safe": "1",
+    "filament_contact_safe": "1",
+    "hole_coef_1": [
+        "0"
+    ],
+    "hole_coef_2": [
+        "-0.008"
+    ],
+    "hole_coef_3": [
+        "0.23415"
+    ],
+    "hole_limit_max": [
+        "0.22"
+    ],
+    "hole_limit_min": [
+        "0.088"
+    ],
+    "impact_strength_z": [
+        "10"
+    ],
+    "long_retractions_when_ec": [
+        "0"
+    ],
+    "no_slow_down_for_cooling_on_outwalls": [
+        "0"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "230"
+    ],
+    "overhang_fan_speed": [
+        "90"
+    ],
+    "overhang_fan_threshold": [
+        "10%"
+    ],
+    "override_process_overhang_speed": [
+        "0"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "retraction_distances_when_ec": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "cooling_slowdown_logic": [
+        "uniform_cooling"
+    ],
+    "cooling_perimeter_transition_distance": [
+        "10"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
+    "supertack_plate_temp": [
+        "80"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "80"
+    ],
+    "temperature_vitrification": [
+        "79"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "volumetric_speed_coefficients": [
+        "0 0 0 0 0 0"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A2L 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        ""
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n\n"
+    ],
+    "inherits": "Generic PETG @BBL A2L",
+    "filament_adhesiveness_category": [
+        "300"
+    ],
+    "filament_id": "PMPE09",
+    "setting_id": "GFSG99_22",
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "version": "2.7.0.8",
+    "idle_temperature": [
+        "0"
+    ]
+}

--- a/preset/PolyMax PETG/Elegoo/CC2/ElegooSlicer/PolyMax PETG @Elegoo CC2.json
+++ b/preset/PolyMax PETG/Elegoo/CC2/ElegooSlicer/PolyMax PETG @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "PolyMax PETG @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "0%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.02"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "30"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "fan_min_speed": [
+        "20"
     ],
     "filament_cost": [
         "30"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.02"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "4"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "260"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "30"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "20"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "260"
     ],
-    "temperature_vitrification": [
-        "79"
-    ],
-    "filament_id": "PMPE09",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "nozzle_temperature_range_low": [
-        "230"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "0%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "79"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Elegoo Centauri Carbon 2 0.4 nozzle"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE09",
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "230"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "additional_cooling_fan_speed": [
         "30"
     ],

--- a/preset/PolyMax PLA/Elegoo/CC2/ElegooSlicer/PolyMax PLA @Elegoo CC2.json
+++ b/preset/PolyMax PLA/Elegoo/CC2/ElegooSlicer/PolyMax PLA @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyMax PLA @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.01"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.19"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.01"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "12"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL32",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL32"
+    ]
 }

--- a/preset/PolyTerra PLA Marble/Elegoo/CC2/ElegooSlicer/PolyTerra PLA Marble @Elegoo CC2.json
+++ b/preset/PolyTerra PLA Marble/Elegoo/CC2/ElegooSlicer/PolyTerra PLA Marble @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyTerra PLA Marble @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.01"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.37"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.01"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL28",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL28"
+    ]
 }

--- a/preset/PolyTerra PLA+/Elegoo/CC2/ElegooSlicer/PolyTerra PLA+ @Elegoo CC2.json
+++ b/preset/PolyTerra PLA+/Elegoo/CC2/ElegooSlicer/PolyTerra PLA+ @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyTerra PLA+ @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.02"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.24"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.02"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "59"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL29",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL29"
+    ]
 }

--- a/preset/PolyTerra PLA/Elegoo/CC2/ElegooSlicer/PolyTerra PLA @Elegoo CC2.json
+++ b/preset/PolyTerra PLA/Elegoo/CC2/ElegooSlicer/PolyTerra PLA @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "PolyTerra PLA @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.01"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.37"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.01"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "8"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "61"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL27",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.7",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL27"
+    ]
 }

--- a/preset/Polymaker ABS Max/Elegoo/CC2/ElegooSlicer/Polymaker ABS Max @Elegoo CC2.json
+++ b/preset/Polymaker ABS Max/Elegoo/CC2/ElegooSlicer/Polymaker ABS Max @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Polymaker ABS Max @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "105"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "105"
-    ],
-    "hot_plate_temp": [
-        "105"
-    ],
-    "textured_plate_temp": [
-        "110"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "105"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "105"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "105"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "110"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "40"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
-        "1"
+        "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "90"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "90"
     ],
     "fan_cooling_layer_time": [
         "22"
     ],
+    "fan_max_speed": [
+        "20"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.06"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,50 +72,69 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "20"
+    "hot_plate_temp": [
+        "90"
     ],
-    "fan_min_speed": [
-        "18"
-    ],
-    "slow_down_min_speed": [
-        "30"
-    ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "90"
     ],
     "nozzle_temperature": [
         "280"
     ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
     "temperature_vitrification": [
         "127.4"
+    ],
+    "textured_plate_temp": [
+        "110"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "110"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic ABS @Elegoo Centauri",
+    "nozzle_temperature_range_high": [
+        "300"
     ],
     "nozzle_temperature_range_low": [
         "270"
     ],
-    "nozzle_temperature_range_high": [
-        "300"
-    ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "filament_id": "PMAB02",
     "setting_id": "GABS00",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "activate_chamber_temp_control": [
         "1"
     ],

--- a/preset/Polymaker ABS Pro Galaxy/Anycubic/Kobra S1/OrcaSlicer/Polymaker ABS Pro Galaxy @Anycubic Kobra S1.json
+++ b/preset/Polymaker ABS Pro Galaxy/Anycubic/Kobra S1/OrcaSlicer/Polymaker ABS Pro Galaxy @Anycubic Kobra S1.json
@@ -3,62 +3,56 @@
     "name": "Polymaker ABS Pro Galaxy @Anycubic Kobra S1",
     "from": "User",
     "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
     "cool_plate_temp": [
-        "105"
-    ],
-    "eng_plate_temp": [
-        "105"
-    ],
-    "hot_plate_temp": [
-        "100"
-    ],
-    "textured_plate_temp": [
-        "100"
+        "0"
     ],
     "cool_plate_temp_initial_layer": [
-        "105"
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "100"
     ],
     "eng_plate_temp_initial_layer": [
         "105"
     ],
-    "hot_plate_temp_initial_layer": [
-        "100"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "100"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "40"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
-    ],
-    "close_fan_the_first_x_layers": [
-        "1"
-    ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
-    ],
-    "filament_flow_ratio": [
-        "0.901"
-    ],
-    "reduce_fan_stop_start_freq": [
-        "1"
-    ],
     "fan_cooling_layer_time": [
         "20"
     ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.04"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.901"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,51 +72,91 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "50"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "20"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "30"
+    "filament_scarf_gap": [
+        "0%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "100"
     ],
     "nozzle_temperature": [
         "280"
     ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "112"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Anycubic Kobra S1 0.4 nozzle"
+    ],
+    "inherits": "Generic ABS @System",
+    "nozzle_temperature_range_high": [
+        "290"
     ],
     "nozzle_temperature_range_low": [
         "270"
     ],
-    "nozzle_temperature_range_high": [
-        "290"
-    ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic ABS",
     "setting_id": "OGFSA04",
     "filament_id": "PMAB03",
-    "compatible_printers": [
-        "Anycubic Kobra S1 0.4 nozzle"
-    ],
     "chamber_temperature": [
         "60"
     ],

--- a/preset/Polymaker ABS Pro Galaxy/Elegoo/CC2/ElegooSlicer/Polymaker ABS Pro Galaxy @Elegoo CC2.json
+++ b/preset/Polymaker ABS Pro Galaxy/Elegoo/CC2/ElegooSlicer/Polymaker ABS Pro Galaxy @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Polymaker ABS Pro Galaxy @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "105"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "105"
-    ],
-    "hot_plate_temp": [
-        "105"
-    ],
-    "textured_plate_temp": [
-        "100"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "105"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "105"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "105"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "100"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "40"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
-        "1"
+        "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.02"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "90"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "90"
     ],
     "fan_cooling_layer_time": [
         "20"
     ],
+    "fan_max_speed": [
+        "60"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.04"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.02"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "4"
@@ -78,50 +72,69 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "60"
+    "hot_plate_temp": [
+        "90"
     ],
-    "fan_min_speed": [
-        "18"
-    ],
-    "slow_down_min_speed": [
-        "30"
-    ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "90"
     ],
     "nozzle_temperature": [
         "280"
     ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
     "temperature_vitrification": [
         "112"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic ABS @Elegoo Centauri",
+    "nozzle_temperature_range_high": [
+        "290"
     ],
     "nozzle_temperature_range_low": [
         "270"
     ],
-    "nozzle_temperature_range_high": [
-        "290"
-    ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "filament_id": "PMAB03",
     "setting_id": "GABS00",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "chamber_temperature": [
         "60"
     ],

--- a/preset/Polymaker ABS Pro Galaxy/Snapmaker/U1/OrcaSlicer/Polymaker ABS Pro Galaxy @Snapmaker U1.json
+++ b/preset/Polymaker ABS Pro Galaxy/Snapmaker/U1/OrcaSlicer/Polymaker ABS Pro Galaxy @Snapmaker U1.json
@@ -3,62 +3,56 @@
     "name": "Polymaker ABS Pro Galaxy @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
     "cool_plate_temp": [
-        "105"
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
     ],
     "eng_plate_temp": [
         "100"
     ],
-    "hot_plate_temp": [
-        "100"
-    ],
-    "textured_plate_temp": [
-        "100"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "105"
-    ],
     "eng_plate_temp_initial_layer": [
         "100"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "100"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "100"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "40"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
-    ],
-    "close_fan_the_first_x_layers": [
-        "1"
-    ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
-    ],
-    "filament_flow_ratio": [
-        "0.9"
-    ],
-    "reduce_fan_stop_start_freq": [
-        "1"
     ],
     "fan_cooling_layer_time": [
         "8"
     ],
+    "fan_max_speed": [
+        "10"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.04"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.9"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -78,51 +72,91 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "fan_min_speed": [
-        "0"
+    "filament_shrink": [
+        "100%"
     ],
-    "slow_down_min_speed": [
-        "30"
+    "hot_plate_temp": [
+        "100"
     ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "100"
     ],
     "nozzle_temperature": [
         "280"
     ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "112"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Snapmaker U1 (0.4 nozzle)"
+    ],
+    "inherits": "Generic ABS @System",
+    "nozzle_temperature_range_high": [
+        "290"
     ],
     "nozzle_temperature_range_low": [
         "270"
     ],
-    "nozzle_temperature_range_high": [
-        "290"
-    ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic ABS",
     "setting_id": "OGFSA04",
     "filament_id": "PMAB03",
-    "compatible_printers": [
-        "Snapmaker U1 (0.4 nozzle)"
-    ],
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Polymaker ABS Pro/Anycubic/Kobra S1/OrcaSlicer/Polymaker ABS Pro @Anycubic Kobra S1.json
+++ b/preset/Polymaker ABS Pro/Anycubic/Kobra S1/OrcaSlicer/Polymaker ABS Pro @Anycubic Kobra S1.json
@@ -3,62 +3,56 @@
     "name": "Polymaker ABS Pro @Anycubic Kobra S1",
     "from": "User",
     "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
     "cool_plate_temp": [
-        "105"
-    ],
-    "eng_plate_temp": [
-        "105"
-    ],
-    "hot_plate_temp": [
-        "100"
-    ],
-    "textured_plate_temp": [
-        "100"
+        "0"
     ],
     "cool_plate_temp_initial_layer": [
-        "105"
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "100"
     ],
     "eng_plate_temp_initial_layer": [
         "105"
     ],
-    "hot_plate_temp_initial_layer": [
-        "100"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "100"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "40"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
-    ],
-    "close_fan_the_first_x_layers": [
-        "1"
-    ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
-    ],
-    "filament_flow_ratio": [
-        "0.901"
-    ],
-    "reduce_fan_stop_start_freq": [
-        "1"
-    ],
     "fan_cooling_layer_time": [
         "20"
     ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.04"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.901"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "8"
@@ -78,51 +72,91 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "50"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "20"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "30"
+    "filament_scarf_gap": [
+        "0%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "100"
     ],
     "nozzle_temperature": [
         "280"
     ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "112"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Anycubic Kobra S1 0.4 nozzle"
+    ],
+    "inherits": "Generic ABS @System",
+    "nozzle_temperature_range_high": [
+        "290"
     ],
     "nozzle_temperature_range_low": [
         "270"
     ],
-    "nozzle_temperature_range_high": [
-        "290"
-    ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic ABS",
     "setting_id": "OGFSA04",
     "filament_id": "PMAB04",
-    "compatible_printers": [
-        "Anycubic Kobra S1 0.4 nozzle"
-    ],
     "chamber_temperature": [
         "60"
     ],

--- a/preset/Polymaker ABS Pro/Elegoo/CC2/ElegooSlicer/Polymaker ABS Pro @Elegoo CC2.json
+++ b/preset/Polymaker ABS Pro/Elegoo/CC2/ElegooSlicer/Polymaker ABS Pro @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Polymaker ABS Pro @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "105"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "105"
-    ],
-    "hot_plate_temp": [
-        "105"
-    ],
-    "textured_plate_temp": [
-        "100"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "105"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "105"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "105"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "100"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "40"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
-        "1"
+        "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.02"
+    "cool_plate_temp": [
+        "0"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "90"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "90"
     ],
     "fan_cooling_layer_time": [
         "20"
     ],
+    "fan_max_speed": [
+        "60"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.04"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.02"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "4"
@@ -78,50 +72,69 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "60"
+    "hot_plate_temp": [
+        "90"
     ],
-    "fan_min_speed": [
-        "18"
-    ],
-    "slow_down_min_speed": [
-        "30"
-    ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "90"
     ],
     "nozzle_temperature": [
         "280"
     ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
     "temperature_vitrification": [
         "112"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        "; Filament start gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "inherits": "Generic ABS @Elegoo Centauri",
+    "nozzle_temperature_range_high": [
+        "290"
     ],
     "nozzle_temperature_range_low": [
         "270"
     ],
-    "nozzle_temperature_range_high": [
-        "290"
-    ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "filament_id": "PMAB04",
     "setting_id": "GABS00",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "chamber_temperature": [
         "60"
     ],

--- a/preset/Polymaker ABS Pro/Snapmaker/U1/OrcaSlicer/Polymaker ABS Pro @Snapmaker U1.json
+++ b/preset/Polymaker ABS Pro/Snapmaker/U1/OrcaSlicer/Polymaker ABS Pro @Snapmaker U1.json
@@ -3,62 +3,56 @@
     "name": "Polymaker ABS Pro @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
     "cool_plate_temp": [
-        "105"
+        "0"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "0"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
     ],
     "eng_plate_temp": [
         "100"
     ],
-    "hot_plate_temp": [
-        "100"
-    ],
-    "textured_plate_temp": [
-        "100"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "105"
-    ],
     "eng_plate_temp_initial_layer": [
         "100"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "100"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "100"
-    ],
-    "overhang_fan_threshold": [
-        "25%"
-    ],
-    "overhang_fan_speed": [
-        "40"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
-    ],
-    "close_fan_the_first_x_layers": [
-        "1"
-    ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
-    ],
-    "filament_flow_ratio": [
-        "0.9"
-    ],
-    "reduce_fan_stop_start_freq": [
-        "1"
     ],
     "fan_cooling_layer_time": [
         "8"
     ],
+    "fan_max_speed": [
+        "10"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.04"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.9"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -78,51 +72,91 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "280"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "fan_min_speed": [
-        "0"
+    "filament_shrink": [
+        "100%"
     ],
-    "slow_down_min_speed": [
-        "30"
+    "hot_plate_temp": [
+        "100"
     ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "100"
     ],
     "nozzle_temperature": [
         "280"
     ],
+    "nozzle_temperature_initial_layer": [
+        "280"
+    ],
+    "overhang_fan_speed": [
+        "80"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "112"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Snapmaker U1 (0.4 nozzle)"
+    ],
+    "inherits": "Generic ABS @System",
+    "nozzle_temperature_range_high": [
+        "290"
     ],
     "nozzle_temperature_range_low": [
         "270"
     ],
-    "nozzle_temperature_range_high": [
-        "290"
-    ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic ABS",
     "setting_id": "OGFSA04",
     "filament_id": "PMAB04",
-    "compatible_printers": [
-        "Snapmaker U1 (0.4 nozzle)"
-    ],
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Polymaker ASA/BBL/X2D/BambuStudio/Polymaker ASA @BBL X2D.json
+++ b/preset/Polymaker ASA/BBL/X2D/BambuStudio/Polymaker ASA @BBL X2D.json
@@ -10,7 +10,7 @@
         "0"
     ],
     "chamber_temperatures": [
-        "0"
+        "65"
     ],
     "circle_compensation_speed": [
         "200"
@@ -52,19 +52,19 @@
         "70"
     ],
     "eng_plate_temp": [
-        "100"
+        "110"
     ],
     "eng_plate_temp_initial_layer": [
-        "100"
+        "110"
     ],
     "fan_cooling_layer_time": [
-        "25"
+        "35"
     ],
     "fan_max_speed": [
         "70"
     ],
     "fan_min_speed": [
-        "0"
+        "20"
     ],
     "filament_adaptive_volumetric_speed": [
         "0"
@@ -142,15 +142,12 @@
         "Bowden High Flow"
     ],
     "filament_flow_ratio": [
-        "0.92",
+        "0.97",
         "nil",
         "nil",
         "nil"
     ],
     "filament_flush_temp": [
-        "0"
-    ],
-    "filament_flush_temp_fast": [
         "0"
     ],
     "filament_flush_volumetric_speed": [
@@ -160,7 +157,7 @@
         "0"
     ],
     "filament_max_volumetric_speed": [
-        "8",
+        "16",
         "nil",
         "nil",
         "nil"
@@ -265,10 +262,10 @@
         "1"
     ],
     "hot_plate_temp": [
-        "100"
+        "110"
     ],
     "hot_plate_temp_initial_layer": [
-        "100"
+        "110"
     ],
     "filament_ingredients_safe": "1",
     "filament_emission_safe": "1",
@@ -346,7 +343,7 @@
         "10"
     ],
     "slow_down_layer_time": [
-        "10"
+        "6"
     ],
     "slow_down_min_speed": [
         "20",
@@ -364,10 +361,10 @@
         "105"
     ],
     "textured_plate_temp": [
-        "100"
+        "110"
     ],
     "textured_plate_temp_initial_layer": [
-        "100"
+        "110"
     ],
     "volumetric_speed_coefficients": [
         "0 0 0 0 0 0"
@@ -381,6 +378,7 @@
     "filament_end_gcode": [
         "; filament end gcode \n\n"
     ],
+    "inherits": "Generic ASA @BBL X2D 0.4 nozzle",
     "filament_adhesiveness_category": [
         "200"
     ],
@@ -390,7 +388,7 @@
     "include": [
         "fdm_filament_template_direct_bowden"
     ],
-    "version": "2.6.0.2",
+    "version": "2.7.0.9",
     "idle_temperature": [
         "0"
     ]

--- a/preset/Polymaker ASA/CreealityPrint/K2Pro/CrealityPrint/Polymaker ASA @CreealityPrint K2Pro.json
+++ b/preset/Polymaker ASA/CreealityPrint/K2Pro/CrealityPrint/Polymaker ASA @CreealityPrint K2Pro.json
@@ -1,0 +1,137 @@
+{
+    "type": "filament",
+    "name": "Polymaker ASA @CreealityPrint K2Pro",
+    "from": "User",
+    "instantiation": "true",
+    "cool_plate_temp": "100",
+    "eng_plate_temp": "105",
+    "hot_plate_temp": "100",
+    "textured_plate_temp": "100",
+    "cool_plate_temp_initial_layer": "100",
+    "eng_plate_temp_initial_layer": "105",
+    "hot_plate_temp_initial_layer": "100",
+    "textured_plate_temp_initial_layer": "100",
+    "overhang_fan_threshold": "25%",
+    "overhang_fan_speed": "100",
+    "slow_down_for_layer_cooling": "1",
+    "close_fan_the_first_x_layers": "3",
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "reduce_fan_stop_start_freq": "1",
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "filament_cost": "30",
+    "filament_density": [
+        "1.13"
+    ],
+    "filament_diameter": "1.75",
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_minimal_purge_on_wipe_tower": "15",
+    "filament_settings_id": [
+        "Polymaker ASA @CreealityPrint K2Pro"
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "ASA"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "bed_type": [
+        "Cool Plate"
+    ],
+    "nozzle_temperature_initial_layer": "260",
+    "full_fan_speed_layer": "0",
+    "fan_max_speed": [
+        "50"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "slow_down_min_speed": "20",
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else} \nM104 S[first_layer_temperature]\n{endif}"
+    ],
+    "nozzle_temperature": "260",
+    "temperature_vitrification": [
+        "105"
+    ],
+    "inherits": "Generic ASA @Creality K2 Pro 0.4 nozzle",
+    "filament_adhesiveness_category": [
+        "200"
+    ],
+    "nozzle_temperature_range_low": [
+        "230"
+    ],
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "filament_id": "PMAS02",
+    "setting_id": "GFSA04",
+    "activate_air_filtration": "0",
+    "activate_chamber_temp_control": "1",
+    "additional_cooling_fan_speed": [
+        "100"
+    ],
+    "chamber_temperature": [
+        "60"
+    ],
+    "compatible_printers": [
+        "Creality K2 Pro 0.4 nozzle"
+    ],
+    "complete_print_exhaust_fan_speed": "80",
+    "cool_cds_fan_start_at_height": "0.5",
+    "cool_special_cds_fan_speed": "0",
+    "customized_plate_temp": "0",
+    "customized_plate_temp_initial_layer": "0",
+    "default_filament_colour": "\"\"",
+    "during_print_exhaust_fan_speed": "60",
+    "enable_overhang_bridge_fan": "1",
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "enable_special_area_additional_cooling_fan": "0",
+    "epoxy_resin_plate_temp": "0",
+    "epoxy_resin_plate_temp_initial_layer": "0",
+    "filament_cooling_final_speed": "3.4",
+    "filament_cooling_initial_speed": "2.2",
+    "filament_cooling_moves": "4",
+    "filament_is_support": "0",
+    "filament_load_time": "0",
+    "filament_loading_speed": "28",
+    "filament_loading_speed_start": "3",
+    "filament_multitool_ramming": "0",
+    "filament_multitool_ramming_flow": "10",
+    "filament_multitool_ramming_volume": "10",
+    "filament_notes": "\"\"",
+    "filament_ramming_parameters": "\"120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6\"",
+    "filament_shrink": "100%",
+    "filament_toolchange_delay": "0",
+    "filament_unload_time": "0",
+    "filament_unloading_speed": "90",
+    "filament_unloading_speed_start": "100",
+    "material_flow_dependent_temperature": "0",
+    "pressure_advance": [
+        "0.044"
+    ],
+    "required_nozzle_HRC": "0",
+    "support_material_interface_fan_speed": "-1",
+    "base_id": "GFSA04",
+    "is_custom_defined": "0",
+    "version": "26.3.30.17",
+    "idle_temperature": [
+        "0"
+    ]
+}

--- a/preset/Polymaker HT-PLA-GF/BBL/A2L/BambuStudio/Polymaker HT-PLA-GF @BBL A2L.json
+++ b/preset/Polymaker HT-PLA-GF/BBL/A2L/BambuStudio/Polymaker HT-PLA-GF @BBL A2L.json
@@ -1,0 +1,369 @@
+{
+    "type": "filament",
+    "name": "Polymaker HT-PLA-GF @BBL A2L",
+    "from": "User",
+    "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "circle_compensation_speed": [
+        "200"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "close_additional_fan_first_x_layers": [
+        "1"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "35"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "counter_coef_1": [
+        "0"
+    ],
+    "counter_coef_2": [
+        "0.008"
+    ],
+    "counter_coef_3": [
+        "-0.041"
+    ],
+    "counter_limit_max": [
+        "0.033"
+    ],
+    "counter_limit_min": [
+        "-0.035"
+    ],
+    "diameter_limit": [
+        "50"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "55"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "55"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_adaptive_volumetric_speed": [
+        "0"
+    ],
+    "filament_extruder_compatibility": [
+        "0"
+    ],
+    "filament_cooling_before_tower": [
+        "0"
+    ],
+    "filament_preheat_temperature_delta": [
+        "0"
+    ],
+    "filament_tower_interface_pre_extrusion_dist": [
+        "10"
+    ],
+    "filament_tower_interface_pre_extrusion_length": [
+        "0"
+    ],
+    "filament_tower_ironing_area": [
+        "4"
+    ],
+    "filament_tower_interface_purge_volume": [
+        "20"
+    ],
+    "filament_tower_interface_print_temp": [
+        "-1"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.34"
+    ],
+    "filament_dev_ams_drying_ams_limitations": [
+        "1",
+        "0"
+    ],
+    "filament_dev_ams_drying_heat_distortion_temperature": [
+        "45"
+    ],
+    "filament_dev_ams_drying_temperature": [
+        "45",
+        "45",
+        "45",
+        "45"
+    ],
+    "filament_dev_ams_drying_time": [
+        "12",
+        "12",
+        "12",
+        "12"
+    ],
+    "filament_dev_chamber_drying_bed_temperature": [
+        "70"
+    ],
+    "filament_dev_chamber_drying_time": [
+        "12.0"
+    ],
+    "filament_dev_drying_cooling_temperature": [
+        "45"
+    ],
+    "filament_dev_drying_softening_temperature": [
+        "50"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_flush_temp": [
+        "0"
+    ],
+    "filament_flush_volumetric_speed": [
+        "0"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_metal_stickiness": [
+        "None"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0"
+    ],
+    "filament_pre_cooling_temperature_nc": [
+        "0"
+    ],
+    "filament_prime_volume": [
+        "45"
+    ],
+    "filament_prime_volume_nc": [
+        "60"
+    ],
+    "filament_printable": [
+        "3"
+    ],
+    "filament_ramming_travel_time_nc": [
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1"
+    ],
+    "filament_ramming_volumetric_speed_nc": [
+        "-1"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_settings_id": [
+        "Polymaker HT-PLA-GF @BBL A2L"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "additional_fan_full_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "15%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_ramming_travel_time": [
+        "0"
+    ],
+    "filament_retract_length_nc": [
+        "14"
+    ],
+    "filament_enable_overhang_speed": [
+        "1"
+    ],
+    "filament_overhang_1_4_speed": [
+        "0"
+    ],
+    "filament_overhang_2_4_speed": [
+        "50"
+    ],
+    "filament_overhang_3_4_speed": [
+        "30"
+    ],
+    "filament_overhang_4_4_speed": [
+        "10"
+    ],
+    "filament_overhang_totally_speed": [
+        "10"
+    ],
+    "filament_bridge_speed": [
+        "25"
+    ],
+    "filament_change_length": [
+        "10"
+    ],
+    "filament_velocity_adaptation_factor": [
+        "1"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_ingredients_safe": "1",
+    "filament_emission_safe": "1",
+    "filament_contact_safe": "1",
+    "hole_coef_1": [
+        "0"
+    ],
+    "hole_coef_2": [
+        "-0.008"
+    ],
+    "hole_coef_3": [
+        "0.23415"
+    ],
+    "hole_limit_max": [
+        "0.22"
+    ],
+    "hole_limit_min": [
+        "0.088"
+    ],
+    "impact_strength_z": [
+        "10.0"
+    ],
+    "long_retractions_when_ec": [
+        "0"
+    ],
+    "no_slow_down_for_cooling_on_outwalls": [
+        "0"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_high": [
+        "230"
+    ],
+    "nozzle_temperature_range_low": [
+        "210"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "override_process_overhang_speed": [
+        "0"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "retraction_distances_when_ec": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "cooling_slowdown_logic": [
+        "uniform_cooling"
+    ],
+    "cooling_perimeter_transition_distance": [
+        "10"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "temperature_vitrification": [
+        "59.76"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "volumetric_speed_coefficients": [
+        "0 0 0 0 0 0"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A2L 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        ""
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n\n"
+    ],
+    "inherits": "Generic PLA @BBL A2L",
+    "filament_adhesiveness_category": [
+        "100"
+    ],
+    "filament_id": "PMHT02",
+    "description": " ",
+    "setting_id": "GFSL99_24",
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "version": "2.7.0.9",
+    "idle_temperature": [
+        "0"
+    ]
+}

--- a/preset/Polymaker HT-PLA-GF/Elegoo/CC2/ElegooSlicer/Polymaker HT-PLA-GF @Elegoo CC2.json
+++ b/preset/Polymaker HT-PLA-GF/Elegoo/CC2/ElegooSlicer/Polymaker HT-PLA-GF @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Polymaker HT-PLA-GF @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.34"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "20"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "59.76"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMHT02",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "210"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMHT02"
+    ]
 }

--- a/preset/Polymaker HT-PLA-GF/Snapmaker/U1/OrcaSlicer/Polymaker HT-PLA-GF @Snapmaker U1.json
+++ b/preset/Polymaker HT-PLA-GF/Snapmaker/U1/OrcaSlicer/Polymaker HT-PLA-GF @Snapmaker U1.json
@@ -3,52 +3,40 @@
     "name": "Polymaker HT-PLA-GF @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "65"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "65"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1.04"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
         "100"
     ],
     "filament_cost": [
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1.04"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "15"
@@ -78,35 +72,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "65"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "65"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "59.76"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Snapmaker U1 (0.4 nozzle)"
+    ],
+    "inherits": "Generic PLA @System",
+    "filament_id": "PMHT02",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "210"
@@ -114,14 +158,8 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic PLA",
     "setting_id": "OGFSA04",
-    "compatible_printers": [
-        "Snapmaker U1 (0.4 nozzle)"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -129,6 +167,5 @@
     "version": "2.3.1.10",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMHT02"
+    ]
 }

--- a/preset/Polymaker HT-PLA/Elegoo/CC2/ElegooSlicer/Polymaker HT-PLA @Elegoo CC2.json
+++ b/preset/Polymaker HT-PLA/Elegoo/CC2/ElegooSlicer/Polymaker HT-PLA @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Polymaker HT-PLA @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "1"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.28"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "20"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "59.8"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMHT01",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "210"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMHT01"
+    ]
 }

--- a/preset/Polymaker HT-PLA/Snapmaker/U1/OrcaSlicer/Polymaker HT-PLA @Snapmaker U1.json
+++ b/preset/Polymaker HT-PLA/Snapmaker/U1/OrcaSlicer/Polymaker HT-PLA @Snapmaker U1.json
@@ -3,52 +3,40 @@
     "name": "Polymaker HT-PLA @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "65"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "65"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.96"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
         "100"
     ],
     "filament_cost": [
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.96"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "15"
@@ -78,35 +72,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "65"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "65"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "59.8"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Snapmaker U1 (0.4 nozzle)"
+    ],
+    "inherits": "Generic PLA @System",
+    "filament_id": "PMHT01",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "210"
@@ -114,14 +158,8 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic PLA",
     "setting_id": "OGFSA04",
-    "compatible_printers": [
-        "Snapmaker U1 (0.4 nozzle)"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -129,6 +167,5 @@
     "version": "2.3.1.10",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMHT01"
+    ]
 }

--- a/preset/Polymaker PETG Galaxy/Elegoo/CC2/ElegooSlicer/Polymaker PETG Galaxy @Elegoo CC2.json
+++ b/preset/Polymaker PETG Galaxy/Elegoo/CC2/ElegooSlicer/Polymaker PETG Galaxy @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "Polymaker PETG Galaxy @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.87"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "16"
+    ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "30"
     ],
     "filament_cost": [
         "30"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.87"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "11"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "260"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "30"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "260"
     ],
-    "temperature_vitrification": [
-        "71.24"
-    ],
-    "filament_id": "PMPE07",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "nozzle_temperature_range_low": [
-        "240"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "71.24"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Elegoo Centauri Carbon 2 0.4 nozzle"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE07",
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Polymaker PETG Galaxy/Snapmaker/U1/OrcaSlicer/Polymaker PETG Galaxy @Snapmaker U1.json
+++ b/preset/Polymaker PETG Galaxy/Snapmaker/U1/OrcaSlicer/Polymaker PETG Galaxy @Snapmaker U1.json
@@ -3,53 +3,41 @@
     "name": "Polymaker PETG Galaxy @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.96"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "30"
+    ],
+    "fan_max_speed": [
+        "10"
+    ],
+    "fan_min_speed": [
+        "50"
     ],
     "filament_cost": [
         "0"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.96"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "15"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "260"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "fan_min_speed": [
-        "50"
+    "filament_shrink": [
+        "100%"
     ],
-    "slow_down_min_speed": [
-        "10"
+    "hot_plate_temp": [
+        "80"
     ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "260"
     ],
-    "temperature_vitrification": [
-        "71.24"
-    ],
-    "filament_id": "PMPE07",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "nozzle_temperature_range_low": [
-        "240"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "71.24"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Snapmaker U1 (0.4 nozzle)"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE07",
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Polymaker PETG/Elegoo/CC2/ElegooSlicer/Polymaker PETG @Elegoo CC2.json
+++ b/preset/Polymaker PETG/Elegoo/CC2/ElegooSlicer/Polymaker PETG @Elegoo CC2.json
@@ -3,53 +3,41 @@
     "name": "Polymaker PETG @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.87"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "16"
+    ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "30"
     ],
     "filament_cost": [
         "30"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.87"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "11"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "260"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "40"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "30"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_shrink": [
+        "100%"
     ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp": [
+        "80"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "260"
     ],
-    "temperature_vitrification": [
-        "71.24"
-    ],
-    "filament_id": "PMPE06",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "nozzle_temperature_range_low": [
-        "240"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "71.24"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Elegoo Centauri Carbon 2 0.4 nozzle"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE06",
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Polymaker PETG/Snapmaker/U1/OrcaSlicer/Polymaker PETG @Snapmaker U1.json
+++ b/preset/Polymaker PETG/Snapmaker/U1/OrcaSlicer/Polymaker PETG @Snapmaker U1.json
@@ -3,53 +3,41 @@
     "name": "Polymaker PETG @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "60"
-    ],
-    "eng_plate_temp": [
+    "activate_air_filtration": [
         "0"
     ],
-    "hot_plate_temp": [
-        "80"
-    ],
-    "textured_plate_temp": [
-        "80"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "60"
-    ],
-    "eng_plate_temp_initial_layer": [
+    "chamber_temperatures": [
         "0"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "80"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "80"
-    ],
-    "overhang_fan_threshold": [
-        "95%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
     ],
     "close_fan_the_first_x_layers": [
         "3"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.96"
+    "cool_plate_temp": [
+        "60"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "60"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "30"
+    ],
+    "fan_max_speed": [
+        "10"
+    ],
+    "fan_min_speed": [
+        "50"
     ],
     "filament_cost": [
         "0"
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.96"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "15"
@@ -78,42 +72,47 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "260"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_length": [
         "10"
     ],
-    "fan_min_speed": [
-        "50"
+    "filament_shrink": [
+        "100%"
     ],
-    "slow_down_min_speed": [
-        "10"
+    "hot_plate_temp": [
+        "80"
     ],
-    "slow_down_layer_time": [
-        "6"
-    ],
-    "filament_start_gcode": [
-        "; Filament gcode\n"
+    "hot_plate_temp_initial_layer": [
+        "80"
     ],
     "nozzle_temperature": [
         "260"
     ],
-    "temperature_vitrification": [
-        "71.24"
-    ],
-    "filament_id": "PMPE06",
-    "nozzle_temperature_range_high": [
+    "nozzle_temperature_initial_layer": [
         "260"
     ],
-    "nozzle_temperature_range_low": [
-        "240"
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "95%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
     ],
     "supertack_plate_temp": [
         "70"
@@ -121,11 +120,43 @@
     "supertack_plate_temp_initial_layer": [
         "70"
     ],
-    "renamed_from": "My Generic PETG",
-    "setting_id": "OGFSA04",
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "temperature_vitrification": [
+        "71.24"
+    ],
+    "textured_plate_temp": [
+        "80"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "80"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
     "compatible_printers": [
         "Snapmaker U1 (0.4 nozzle)"
     ],
+    "inherits": "Generic PETG @System",
+    "filament_id": "PMPE06",
+    "nozzle_temperature_range_high": [
+        "260"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "renamed_from": "My Generic PETG",
+    "setting_id": "OGFSA04",
     "enable_pressure_advance": [
         "1"
     ],

--- a/preset/Polymaker PLA Pro Metallic/Anycubic/Kobra S1/OrcaSlicer/Polymaker PLA Pro Metallic @Anycubic Kobra S1.json
+++ b/preset/Polymaker PLA Pro Metallic/Anycubic/Kobra S1/OrcaSlicer/Polymaker PLA Pro Metallic @Anycubic Kobra S1.json
@@ -3,52 +3,40 @@
     "name": "Polymaker PLA Pro Metallic @Anycubic Kobra S1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.85"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
         "100"
     ],
     "filament_cost": [
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.85"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -78,35 +72,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
+    "filament_scarf_length": [
         "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "55"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Anycubic Kobra S1 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA @System",
+    "filament_id": "PMPL26",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -114,18 +158,11 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic PLA",
     "setting_id": "OGFSA04",
-    "compatible_printers": [
-        "Anycubic Kobra S1 0.4 nozzle"
-    ],
     "is_custom_defined": "0",
     "version": "2.3.1.10",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL26"
+    ]
 }

--- a/preset/Polymaker PLA Pro Metallic/Elegoo/CC2/ElegooSlicer/Polymaker PLA Pro Metallic @Elegoo CC2.json
+++ b/preset/Polymaker PLA Pro Metallic/Elegoo/CC2/ElegooSlicer/Polymaker PLA Pro Metallic @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Polymaker PLA Pro Metallic @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.97"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.23"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.97"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "12"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "55"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL26",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL26"
+    ]
 }

--- a/preset/Polymaker PLA Pro Metallic/Snapmaker/U1/OrcaSlicer/Polymaker PLA Pro Metallic @Snapmaker U1.json
+++ b/preset/Polymaker PLA Pro Metallic/Snapmaker/U1/OrcaSlicer/Polymaker PLA Pro Metallic @Snapmaker U1.json
@@ -3,52 +3,40 @@
     "name": "Polymaker PLA Pro Metallic @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "65"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "65"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.96"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
         "100"
     ],
     "filament_cost": [
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.96"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "15"
@@ -78,35 +72,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "65"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "65"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "55"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Snapmaker U1 (0.4 nozzle)"
+    ],
+    "inherits": "Generic PLA @System",
+    "filament_id": "PMPL26",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -114,14 +158,8 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic PLA",
     "setting_id": "OGFSA04",
-    "compatible_printers": [
-        "Snapmaker U1 (0.4 nozzle)"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -129,6 +167,5 @@
     "version": "2.3.1.10",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL26"
+    ]
 }

--- a/preset/Polymaker PLA Pro/Anycubic/Kobra S1/OrcaSlicer/Polymaker PLA Pro @Anycubic Kobra S1.json
+++ b/preset/Polymaker PLA Pro/Anycubic/Kobra S1/OrcaSlicer/Polymaker PLA Pro @Anycubic Kobra S1.json
@@ -3,52 +3,40 @@
     "name": "Polymaker PLA Pro @Anycubic Kobra S1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.85"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
         "100"
     ],
     "filament_cost": [
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.85"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -78,35 +72,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
+    "filament_scarf_length": [
         "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "55"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Anycubic Kobra S1 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA @System",
+    "filament_id": "PMPL25",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -114,18 +158,11 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic PLA",
     "setting_id": "OGFSA04",
-    "compatible_printers": [
-        "Anycubic Kobra S1 0.4 nozzle"
-    ],
     "is_custom_defined": "0",
     "version": "2.3.1.10",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL25"
+    ]
 }

--- a/preset/Polymaker PLA Pro/Elegoo/CC2/ElegooSlicer/Polymaker PLA Pro @Elegoo CC2.json
+++ b/preset/Polymaker PLA Pro/Elegoo/CC2/ElegooSlicer/Polymaker PLA Pro @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Polymaker PLA Pro @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.97"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.23"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.97"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "12"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "55"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL25",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL25"
+    ]
 }

--- a/preset/Polymaker PLA Pro/Snapmaker/U1/OrcaSlicer/Polymaker PLA Pro @Snapmaker U1.json
+++ b/preset/Polymaker PLA Pro/Snapmaker/U1/OrcaSlicer/Polymaker PLA Pro @Snapmaker U1.json
@@ -3,52 +3,40 @@
     "name": "Polymaker PLA Pro @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "65"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "65"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.96"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
         "100"
     ],
     "filament_cost": [
@@ -59,6 +47,12 @@
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.96"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "15"
@@ -78,35 +72,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "65"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "65"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "55"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Snapmaker U1 (0.4 nozzle)"
+    ],
+    "inherits": "Generic PLA @System",
+    "filament_id": "PMPL25",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -114,14 +158,8 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic PLA",
     "setting_id": "OGFSA04",
-    "compatible_printers": [
-        "Snapmaker U1 (0.4 nozzle)"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -129,6 +167,5 @@
     "version": "2.3.1.10",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL25"
+    ]
 }

--- a/preset/Polymaker PLA/BBL/A2L/BambuStudio/Polymaker PLA @BBL A2L.json
+++ b/preset/Polymaker PLA/BBL/A2L/BambuStudio/Polymaker PLA @BBL A2L.json
@@ -1,0 +1,369 @@
+{
+    "type": "filament",
+    "name": "Polymaker PLA @BBL A2L",
+    "from": "User",
+    "instantiation": "true",
+    "activate_air_filtration": [
+        "0"
+    ],
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "chamber_temperatures": [
+        "0"
+    ],
+    "circle_compensation_speed": [
+        "200"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "close_additional_fan_first_x_layers": [
+        "1"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "35"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "counter_coef_1": [
+        "0"
+    ],
+    "counter_coef_2": [
+        "0.008"
+    ],
+    "counter_coef_3": [
+        "-0.041"
+    ],
+    "counter_limit_max": [
+        "0.033"
+    ],
+    "counter_limit_min": [
+        "-0.035"
+    ],
+    "diameter_limit": [
+        "50"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "55"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "55"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_adaptive_volumetric_speed": [
+        "0"
+    ],
+    "filament_extruder_compatibility": [
+        "0"
+    ],
+    "filament_cooling_before_tower": [
+        "0"
+    ],
+    "filament_preheat_temperature_delta": [
+        "0"
+    ],
+    "filament_tower_interface_pre_extrusion_dist": [
+        "10"
+    ],
+    "filament_tower_interface_pre_extrusion_length": [
+        "0"
+    ],
+    "filament_tower_ironing_area": [
+        "4"
+    ],
+    "filament_tower_interface_purge_volume": [
+        "20"
+    ],
+    "filament_tower_interface_print_temp": [
+        "-1"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "filament_density": [
+        "1.23"
+    ],
+    "filament_dev_ams_drying_ams_limitations": [
+        "1",
+        "0"
+    ],
+    "filament_dev_ams_drying_heat_distortion_temperature": [
+        "45"
+    ],
+    "filament_dev_ams_drying_temperature": [
+        "45",
+        "45",
+        "45",
+        "45"
+    ],
+    "filament_dev_ams_drying_time": [
+        "12",
+        "12",
+        "12",
+        "12"
+    ],
+    "filament_dev_chamber_drying_bed_temperature": [
+        "70"
+    ],
+    "filament_dev_chamber_drying_time": [
+        "12.0"
+    ],
+    "filament_dev_drying_cooling_temperature": [
+        "45"
+    ],
+    "filament_dev_drying_softening_temperature": [
+        "50"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_flush_temp": [
+        "0"
+    ],
+    "filament_flush_volumetric_speed": [
+        "0"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_metal_stickiness": [
+        "None"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0"
+    ],
+    "filament_pre_cooling_temperature_nc": [
+        "0"
+    ],
+    "filament_prime_volume": [
+        "45"
+    ],
+    "filament_prime_volume_nc": [
+        "60"
+    ],
+    "filament_printable": [
+        "3"
+    ],
+    "filament_ramming_travel_time_nc": [
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1"
+    ],
+    "filament_ramming_volumetric_speed_nc": [
+        "-1"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_settings_id": [
+        "Polymaker PLA @BBL A2L"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "Polymaker"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "additional_fan_full_speed_layer": [
+        "0"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_gap": [
+        "15%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_ramming_travel_time": [
+        "0"
+    ],
+    "filament_retract_length_nc": [
+        "14"
+    ],
+    "filament_enable_overhang_speed": [
+        "1"
+    ],
+    "filament_overhang_1_4_speed": [
+        "0"
+    ],
+    "filament_overhang_2_4_speed": [
+        "50"
+    ],
+    "filament_overhang_3_4_speed": [
+        "30"
+    ],
+    "filament_overhang_4_4_speed": [
+        "10"
+    ],
+    "filament_overhang_totally_speed": [
+        "10"
+    ],
+    "filament_bridge_speed": [
+        "25"
+    ],
+    "filament_change_length": [
+        "10"
+    ],
+    "filament_velocity_adaptation_factor": [
+        "1"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_ingredients_safe": "1",
+    "filament_emission_safe": "1",
+    "filament_contact_safe": "1",
+    "hole_coef_1": [
+        "0"
+    ],
+    "hole_coef_2": [
+        "-0.008"
+    ],
+    "hole_coef_3": [
+        "0.23415"
+    ],
+    "hole_limit_max": [
+        "0.22"
+    ],
+    "hole_limit_min": [
+        "0.088"
+    ],
+    "impact_strength_z": [
+        "10.0"
+    ],
+    "long_retractions_when_ec": [
+        "0"
+    ],
+    "no_slow_down_for_cooling_on_outwalls": [
+        "0"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "nozzle_temperature_range_high": [
+        "230"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "override_process_overhang_speed": [
+        "0"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "retraction_distances_when_ec": [
+        "0"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "cooling_slowdown_logic": [
+        "uniform_cooling"
+    ],
+    "cooling_perimeter_transition_distance": [
+        "10"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "temperature_vitrification": [
+        "59"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "volumetric_speed_coefficients": [
+        "0 0 0 0 0 0"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A2L 0.4 nozzle"
+    ],
+    "filament_start_gcode": [
+        ""
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n\n"
+    ],
+    "inherits": "Generic PLA @BBL A2L",
+    "filament_adhesiveness_category": [
+        "100"
+    ],
+    "filament_id": "PMPL24",
+    "description": " ",
+    "setting_id": "GFSL99_24",
+    "pre_start_fan_time": [
+        "2"
+    ],
+    "version": "2.7.0.9",
+    "idle_temperature": [
+        "0"
+    ]
+}

--- a/preset/Polymaker PLA/Elegoo/CC2/ElegooSlicer/Polymaker PLA @Elegoo CC2.json
+++ b/preset/Polymaker PLA/Elegoo/CC2/ElegooSlicer/Polymaker PLA @Elegoo CC2.json
@@ -3,62 +3,56 @@
     "name": "Polymaker PLA @Elegoo CC2",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.99"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.23"
     ],
     "filament_diameter": [
         "1.75"
+    ],
+    "filament_flow_ratio": [
+        "0.99"
+    ],
+    "filament_is_support": [
+        "0"
     ],
     "filament_max_volumetric_speed": [
         "16"
@@ -81,35 +75,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "6"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "6"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "59"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Elegoo Centauri Carbon 2 0.4 nozzle"
+    ],
+    "inherits": "Generic PLA Matte @System",
+    "filament_id": "PMPL24",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -117,13 +161,7 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "setting_id": "OGFSL99_02",
-    "compatible_printers": [
-        "Elegoo Centauri Carbon 2 0.4 nozzle"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "1.3.0.11",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL24"
+    ]
 }

--- a/preset/Polymaker PLA/Snapmaker/U1/OrcaSlicer/Polymaker PLA @Snapmaker U1.json
+++ b/preset/Polymaker PLA/Snapmaker/U1/OrcaSlicer/Polymaker PLA @Snapmaker U1.json
@@ -3,56 +3,44 @@
     "name": "Polymaker PLA @Snapmaker U1",
     "from": "User",
     "instantiation": "true",
-    "cool_plate_temp": [
-        "50"
+    "activate_air_filtration": [
+        "0"
     ],
-    "eng_plate_temp": [
-        "50"
-    ],
-    "hot_plate_temp": [
-        "50"
-    ],
-    "textured_plate_temp": [
-        "50"
-    ],
-    "cool_plate_temp_initial_layer": [
-        "50"
-    ],
-    "eng_plate_temp_initial_layer": [
-        "50"
-    ],
-    "hot_plate_temp_initial_layer": [
-        "50"
-    ],
-    "textured_plate_temp_initial_layer": [
-        "50"
-    ],
-    "overhang_fan_threshold": [
-        "50%"
-    ],
-    "overhang_fan_speed": [
-        "100"
-    ],
-    "slow_down_for_layer_cooling": [
-        "1"
+    "chamber_temperatures": [
+        "0"
     ],
     "close_fan_the_first_x_layers": [
         "1"
     ],
-    "filament_end_gcode": [
-        "; filament end gcode \n"
+    "complete_print_exhaust_fan_speed": [
+        "70"
     ],
-    "filament_flow_ratio": [
-        "0.96"
+    "cool_plate_temp": [
+        "35"
     ],
-    "reduce_fan_stop_start_freq": [
-        "1"
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "eng_plate_temp": [
+        "0"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "0"
     ],
     "fan_cooling_layer_time": [
         "100"
     ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
     "filament_cost": [
-        "30"
+        "20"
     ],
     "filament_density": [
         "1.23"
@@ -60,8 +48,14 @@
     "filament_diameter": [
         "1.75"
     ],
+    "filament_flow_ratio": [
+        "0.96"
+    ],
+    "filament_is_support": [
+        "0"
+    ],
     "filament_max_volumetric_speed": [
-        "20"
+        "12"
     ],
     "filament_minimal_purge_on_wipe_tower": [
         "15"
@@ -78,35 +72,85 @@
     "filament_vendor": [
         "Polymaker"
     ],
-    "bed_type": [
-        "Cool Plate"
-    ],
-    "nozzle_temperature_initial_layer": [
-        "220"
-    ],
     "full_fan_speed_layer": [
         "0"
     ],
-    "fan_max_speed": [
-        "100"
+    "filament_scarf_seam_type": [
+        "none"
     ],
-    "fan_min_speed": [
-        "100"
+    "filament_scarf_height": [
+        "10%"
     ],
-    "slow_down_min_speed": [
-        "5"
+    "filament_scarf_gap": [
+        "15%"
     ],
-    "slow_down_layer_time": [
-        "5"
+    "filament_scarf_length": [
+        "10"
     ],
-    "filament_start_gcode": [
-        "; filament start gcode\n"
+    "filament_shrink": [
+        "100%"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
     ],
     "nozzle_temperature": [
         "220"
     ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
     "temperature_vitrification": [
         "59"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ],
+    "filament_start_gcode": [
+        "; Filament gcode\n"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode\n"
+    ],
+    "compatible_printers": [
+        "Snapmaker U1 (0.4 nozzle)"
+    ],
+    "inherits": "Generic PLA @System",
+    "filament_id": "PMPL24",
+    "additional_cooling_fan_speed": [
+        "70"
     ],
     "nozzle_temperature_range_low": [
         "190"
@@ -114,14 +158,8 @@
     "nozzle_temperature_range_high": [
         "230"
     ],
-    "additional_cooling_fan_speed": [
-        "0"
-    ],
     "renamed_from": "My Generic PLA",
     "setting_id": "OGFSA04",
-    "compatible_printers": [
-        "Snapmaker U1 (0.4 nozzle)"
-    ],
     "enable_pressure_advance": [
         "1"
     ],
@@ -134,6 +172,5 @@
     "version": "2.3.2.60",
     "idle_temperature": [
         "0"
-    ],
-    "filament_id": "PMPL24"
+    ]
 }


### PR DESCRIPTION
## Summary

This PR updates 82 material preset files across 54 materials. It improves preset compatibility with the latest slicer parameters, corrects temperature and cooling settings, and adds several new printer-material combinations.

## Fixed

- Fixed outdated or incomplete temperature and cooling settings in selected Fiberon, Panchroma, PolyLite, PolyMax, PolyTerra, and Polymaker profiles.
- Corrected build plate temperatures for Cool Plate, Engineering Plate, Hot Plate, Textured Plate, and Supertack Plate where applicable.
- Fixed fan behavior, including auxiliary cooling, overhang cooling, first-layer fan control, and minimum slowdown speed.
- Corrected the vitrification temperature for the PolyMax PC profile.
- Updated the Polymaker ASA profile for Bambu Lab X2D, including chamber temperature, plate temperature, flow ratio, cooling behavior, and maximum volumetric speed.
- Standardized filament start and end G-code formatting across updated profiles.

## Added

Added the following new material profiles:

- PolyMax PC for Elegoo CC2
- PolyMax PETG for Bambu Lab A2L
- Polymaker ASA for Creality K2 Pro
- Polymaker HT-PLA-GF for Bambu Lab A2L
- Polymaker PLA for Bambu Lab A2L

The updated profiles also include additional slicer parameters where supported:

- Air filtration control
- Chamber temperature
- Exhaust fan speed during printing
- Exhaust fan speed after printing
- Support material identification
- Required nozzle hardness
- Filament shrinkage
- Scarf seam settings
- Supertack Plate temperatures

## Changed

- Updated 77 existing profiles for:
  - Elegoo CC2
  - Snapmaker U1
  - Anycubic Kobra S1
  - Bambu Lab A2L, H2D, and X2D
- Adjusted plate temperatures, cooling fan speeds, slowdown behavior, material cost, flow ratio, and maximum volumetric speed where needed.
- Updated several profiles to use the latest slicer-compatible parameter structure.
- Removed the obsolete `bed_type` field from updated profiles.
- Improved consistency between profiles for different printers and slicers.

## Compatibility

This update covers profiles used with:

- Bambu Studio
- Elegoo Slicer
- OrcaSlicer
- Creality Print