### PR TITLE
Update presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
   "@type": "ItemList",
   "name": "Polymaker filament presets",
   "description": "Official Polymaker 3D printing filament presets by material, printer, and slicer for Bambu Studio, OrcaSlicer, ElegooSlicer, and PrusaSlicer.",
-  "numberOfItems": 762,
+  "numberOfItems": 779,
   "itemListElement": [
     {
       "@type": "ListItem",
@@ -2068,7 +2068,7 @@
       "position": 145,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Celestial filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Celestial filament preset for Creality I7 (CrealityPrint)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2082,7 +2082,7 @@
       "position": 146,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Celestial filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Celestial filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2096,7 +2096,7 @@
       "position": 147,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Celestial filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Celestial filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2110,12 +2110,12 @@
       "position": 148,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Celestial filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Galaxy",
+        "category": "Panchroma PLA Celestial",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2124,7 +2124,7 @@
       "position": 149,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2138,7 +2138,7 @@
       "position": 150,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2152,7 +2152,7 @@
       "position": 151,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2166,7 +2166,7 @@
       "position": 152,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2180,7 +2180,7 @@
       "position": 153,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2194,7 +2194,7 @@
       "position": 154,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2208,7 +2208,7 @@
       "position": 155,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2222,7 +2222,7 @@
       "position": 156,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2236,7 +2236,7 @@
       "position": 157,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2250,7 +2250,7 @@
       "position": 158,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2264,7 +2264,7 @@
       "position": 159,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2278,7 +2278,7 @@
       "position": 160,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2292,7 +2292,7 @@
       "position": 161,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2306,7 +2306,7 @@
       "position": 162,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2320,7 +2320,7 @@
       "position": 163,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2334,7 +2334,7 @@
       "position": 164,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Creality I7 (CrealityPrint)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2348,7 +2348,7 @@
       "position": 165,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Galaxy filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2362,12 +2362,12 @@
       "position": 166,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Glow",
+        "category": "Panchroma PLA Galaxy",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2376,12 +2376,12 @@
       "position": 167,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Galaxy filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Glow",
+        "category": "Panchroma PLA Galaxy",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2390,7 +2390,7 @@
       "position": 168,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2404,7 +2404,7 @@
       "position": 169,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2418,7 +2418,7 @@
       "position": 170,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2432,7 +2432,7 @@
       "position": 171,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2446,7 +2446,7 @@
       "position": 172,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2460,7 +2460,7 @@
       "position": 173,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2474,7 +2474,7 @@
       "position": 174,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2488,7 +2488,7 @@
       "position": 175,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2502,7 +2502,7 @@
       "position": 176,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2516,7 +2516,7 @@
       "position": 177,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2530,7 +2530,7 @@
       "position": 178,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2544,7 +2544,7 @@
       "position": 179,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2558,7 +2558,7 @@
       "position": 180,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2572,7 +2572,7 @@
       "position": 181,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2586,7 +2586,7 @@
       "position": 182,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2600,7 +2600,7 @@
       "position": 183,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Glow filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Creality I7 (CrealityPrint)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2614,12 +2614,12 @@
       "position": 184,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Luminous",
+        "category": "Panchroma PLA Glow",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2628,12 +2628,12 @@
       "position": 185,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Luminous",
+        "category": "Panchroma PLA Glow",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2642,12 +2642,12 @@
       "position": 186,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Glow filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Luminous",
+        "category": "Panchroma PLA Glow",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2656,7 +2656,7 @@
       "position": 187,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2670,7 +2670,7 @@
       "position": 188,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2684,7 +2684,7 @@
       "position": 189,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2698,7 +2698,7 @@
       "position": 190,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2712,7 +2712,7 @@
       "position": 191,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2726,7 +2726,7 @@
       "position": 192,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2740,7 +2740,7 @@
       "position": 193,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2754,7 +2754,7 @@
       "position": 194,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2768,7 +2768,7 @@
       "position": 195,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2782,7 +2782,7 @@
       "position": 196,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2796,7 +2796,7 @@
       "position": 197,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2810,7 +2810,7 @@
       "position": 198,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2824,7 +2824,7 @@
       "position": 199,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2838,7 +2838,7 @@
       "position": 200,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2852,7 +2852,7 @@
       "position": 201,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Luminous filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2866,12 +2866,12 @@
       "position": 202,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Creality I7 (CrealityPrint)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Marble",
+        "category": "Panchroma PLA Luminous",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2880,12 +2880,12 @@
       "position": 203,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Marble",
+        "category": "Panchroma PLA Luminous",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2894,12 +2894,12 @@
       "position": 204,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Marble",
+        "category": "Panchroma PLA Luminous",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2908,12 +2908,12 @@
       "position": 205,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Luminous filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Marble",
+        "category": "Panchroma PLA Luminous",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -2922,7 +2922,7 @@
       "position": 206,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2936,7 +2936,7 @@
       "position": 207,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2950,7 +2950,7 @@
       "position": 208,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2964,7 +2964,7 @@
       "position": 209,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2978,7 +2978,7 @@
       "position": 210,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -2992,7 +2992,7 @@
       "position": 211,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3006,7 +3006,7 @@
       "position": 212,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3020,7 +3020,7 @@
       "position": 213,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3034,7 +3034,7 @@
       "position": 214,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3048,7 +3048,7 @@
       "position": 215,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3062,7 +3062,7 @@
       "position": 216,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3076,7 +3076,7 @@
       "position": 217,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Marble filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3090,12 +3090,12 @@
       "position": 218,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Matte",
+        "category": "Panchroma PLA Marble",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3104,12 +3104,12 @@
       "position": 219,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Matte",
+        "category": "Panchroma PLA Marble",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3118,12 +3118,12 @@
       "position": 220,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Matte",
+        "category": "Panchroma PLA Marble",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3132,12 +3132,12 @@
       "position": 221,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Marble filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Matte",
+        "category": "Panchroma PLA Marble",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3146,7 +3146,7 @@
       "position": 222,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3160,7 +3160,7 @@
       "position": 223,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3174,7 +3174,7 @@
       "position": 224,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3188,7 +3188,7 @@
       "position": 225,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3202,7 +3202,7 @@
       "position": 226,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3216,7 +3216,7 @@
       "position": 227,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3230,7 +3230,7 @@
       "position": 228,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3244,7 +3244,7 @@
       "position": 229,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3258,7 +3258,7 @@
       "position": 230,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3272,7 +3272,7 @@
       "position": 231,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3286,7 +3286,7 @@
       "position": 232,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3300,7 +3300,7 @@
       "position": 233,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Matte filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3314,12 +3314,12 @@
       "position": 234,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Metallic",
+        "category": "Panchroma PLA Matte",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3328,12 +3328,12 @@
       "position": 235,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Metallic",
+        "category": "Panchroma PLA Matte",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3342,12 +3342,12 @@
       "position": 236,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Metallic",
+        "category": "Panchroma PLA Matte",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3356,12 +3356,12 @@
       "position": 237,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Matte filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Metallic",
+        "category": "Panchroma PLA Matte",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3370,7 +3370,7 @@
       "position": 238,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3384,7 +3384,7 @@
       "position": 239,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3398,7 +3398,7 @@
       "position": 240,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3412,7 +3412,7 @@
       "position": 241,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3426,7 +3426,7 @@
       "position": 242,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3440,7 +3440,7 @@
       "position": 243,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3454,7 +3454,7 @@
       "position": 244,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3468,7 +3468,7 @@
       "position": 245,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3482,7 +3482,7 @@
       "position": 246,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3496,7 +3496,7 @@
       "position": 247,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3510,7 +3510,7 @@
       "position": 248,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3524,7 +3524,7 @@
       "position": 249,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3538,7 +3538,7 @@
       "position": 250,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3552,7 +3552,7 @@
       "position": 251,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Metallic filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3566,12 +3566,12 @@
       "position": 252,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Neon",
+        "category": "Panchroma PLA Metallic",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3580,12 +3580,12 @@
       "position": 253,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Creality I7 (CrealityPrint)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Neon",
+        "category": "Panchroma PLA Metallic",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3594,12 +3594,12 @@
       "position": 254,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Neon",
+        "category": "Panchroma PLA Metallic",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3608,12 +3608,12 @@
       "position": 255,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Neon",
+        "category": "Panchroma PLA Metallic",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3622,12 +3622,12 @@
       "position": 256,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Metallic filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Neon",
+        "category": "Panchroma PLA Metallic",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3636,7 +3636,7 @@
       "position": 257,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3650,7 +3650,7 @@
       "position": 258,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3664,7 +3664,7 @@
       "position": 259,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3678,7 +3678,7 @@
       "position": 260,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3692,7 +3692,7 @@
       "position": 261,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3706,7 +3706,7 @@
       "position": 262,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3720,7 +3720,7 @@
       "position": 263,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3734,7 +3734,7 @@
       "position": 264,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3748,7 +3748,7 @@
       "position": 265,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3762,7 +3762,7 @@
       "position": 266,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3776,7 +3776,7 @@
       "position": 267,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3790,7 +3790,7 @@
       "position": 268,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3804,7 +3804,7 @@
       "position": 269,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Neon filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3818,12 +3818,12 @@
       "position": 270,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Satin",
+        "category": "Panchroma PLA Neon",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3832,12 +3832,12 @@
       "position": 271,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Satin",
+        "category": "Panchroma PLA Neon",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3846,12 +3846,12 @@
       "position": 272,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Creality I7 (CrealityPrint)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Satin",
+        "category": "Panchroma PLA Neon",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3860,12 +3860,12 @@
       "position": 273,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Satin",
+        "category": "Panchroma PLA Neon",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3874,12 +3874,12 @@
       "position": 274,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Satin",
+        "category": "Panchroma PLA Neon",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3888,12 +3888,12 @@
       "position": 275,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Neon filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Satin",
+        "category": "Panchroma PLA Neon",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -3902,7 +3902,7 @@
       "position": 276,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3916,7 +3916,7 @@
       "position": 277,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3930,7 +3930,7 @@
       "position": 278,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3944,7 +3944,7 @@
       "position": 279,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3958,7 +3958,7 @@
       "position": 280,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3972,7 +3972,7 @@
       "position": 281,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -3986,7 +3986,7 @@
       "position": 282,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4000,7 +4000,7 @@
       "position": 283,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4014,7 +4014,7 @@
       "position": 284,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Satin filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4028,12 +4028,12 @@
       "position": 285,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Silk",
+        "category": "Panchroma PLA Satin",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4042,12 +4042,12 @@
       "position": 286,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Silk",
+        "category": "Panchroma PLA Satin",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4056,12 +4056,12 @@
       "position": 287,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Silk",
+        "category": "Panchroma PLA Satin",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4070,12 +4070,12 @@
       "position": 288,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Silk",
+        "category": "Panchroma PLA Satin",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4084,12 +4084,12 @@
       "position": 289,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Silk",
+        "category": "Panchroma PLA Satin",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4098,12 +4098,12 @@
       "position": 290,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Satin filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Silk",
+        "category": "Panchroma PLA Satin",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4112,7 +4112,7 @@
       "position": 291,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4126,7 +4126,7 @@
       "position": 292,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4140,7 +4140,7 @@
       "position": 293,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4154,7 +4154,7 @@
       "position": 294,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4168,7 +4168,7 @@
       "position": 295,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4182,7 +4182,7 @@
       "position": 296,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4196,7 +4196,7 @@
       "position": 297,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4210,7 +4210,7 @@
       "position": 298,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4224,7 +4224,7 @@
       "position": 299,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4238,7 +4238,7 @@
       "position": 300,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4252,7 +4252,7 @@
       "position": 301,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Silk filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4266,12 +4266,12 @@
       "position": 302,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Starlight",
+        "category": "Panchroma PLA Silk",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4280,12 +4280,12 @@
       "position": 303,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Starlight",
+        "category": "Panchroma PLA Silk",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4294,12 +4294,12 @@
       "position": 304,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Starlight",
+        "category": "Panchroma PLA Silk",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4308,12 +4308,12 @@
       "position": 305,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Starlight",
+        "category": "Panchroma PLA Silk",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4322,12 +4322,12 @@
       "position": 306,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Starlight",
+        "category": "Panchroma PLA Silk",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4336,12 +4336,12 @@
       "position": 307,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Silk filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Starlight",
+        "category": "Panchroma PLA Silk",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4350,7 +4350,7 @@
       "position": 308,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4364,7 +4364,7 @@
       "position": 309,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4378,7 +4378,7 @@
       "position": 310,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4392,7 +4392,7 @@
       "position": 311,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4406,7 +4406,7 @@
       "position": 312,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4420,7 +4420,7 @@
       "position": 313,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4434,7 +4434,7 @@
       "position": 314,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4448,7 +4448,7 @@
       "position": 315,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4462,7 +4462,7 @@
       "position": 316,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4476,7 +4476,7 @@
       "position": 317,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4490,7 +4490,7 @@
       "position": 318,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4504,7 +4504,7 @@
       "position": 319,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Starlight filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4518,12 +4518,12 @@
       "position": 320,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Anycubic Kobra S1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Translucent",
+        "category": "Panchroma PLA Starlight",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4532,12 +4532,12 @@
       "position": 321,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Translucent",
+        "category": "Panchroma PLA Starlight",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4546,12 +4546,12 @@
       "position": 322,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Translucent",
+        "category": "Panchroma PLA Starlight",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4560,12 +4560,12 @@
       "position": 323,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Creality I7 (CrealityPrint)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Translucent",
+        "category": "Panchroma PLA Starlight",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4574,12 +4574,12 @@
       "position": 324,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Translucent",
+        "category": "Panchroma PLA Starlight",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4588,12 +4588,12 @@
       "position": 325,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Translucent",
+        "category": "Panchroma PLA Starlight",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4602,12 +4602,12 @@
       "position": 326,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Starlight filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA Translucent",
+        "category": "Panchroma PLA Starlight",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4616,7 +4616,7 @@
       "position": 327,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Anycubic Kobra S1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4630,7 +4630,7 @@
       "position": 328,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4644,7 +4644,7 @@
       "position": 329,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4658,7 +4658,7 @@
       "position": 330,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4672,7 +4672,7 @@
       "position": 331,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4686,7 +4686,7 @@
       "position": 332,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4700,7 +4700,7 @@
       "position": 333,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4714,7 +4714,7 @@
       "position": 334,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4728,7 +4728,7 @@
       "position": 335,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4742,7 +4742,7 @@
       "position": 336,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Creality I7 (CrealityPrint)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4756,7 +4756,7 @@
       "position": 337,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Creality K2Pro (CrealityPrint)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4770,7 +4770,7 @@
       "position": 338,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4784,7 +4784,7 @@
       "position": 339,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab P2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4798,7 +4798,7 @@
       "position": 340,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for QIDI Q2 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab X1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4812,7 +4812,7 @@
       "position": 341,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA Translucent filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab X1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4826,12 +4826,12 @@
       "position": 342,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Bambu Lab X2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA UV Shift",
+        "category": "Panchroma PLA Translucent",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4840,12 +4840,12 @@
       "position": 343,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Creality I7 (CrealityPrint)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA UV Shift",
+        "category": "Panchroma PLA Translucent",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4854,12 +4854,12 @@
       "position": 344,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A1 mini (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Creality K2Pro (CrealityPrint)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA UV Shift",
+        "category": "Panchroma PLA Translucent",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4868,12 +4868,12 @@
       "position": 345,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A1 mini (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA UV Shift",
+        "category": "Panchroma PLA Translucent",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4882,12 +4882,12 @@
       "position": 346,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A2L (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Prusa Core One (PrusaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA UV Shift",
+        "category": "Panchroma PLA Translucent",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4896,12 +4896,12 @@
       "position": 347,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab H2C (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for QIDI Q2 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA UV Shift",
+        "category": "Panchroma PLA Translucent",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4910,12 +4910,12 @@
       "position": 348,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab H2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA Translucent filament preset for Snapmaker U1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
         },
-        "category": "Panchroma PLA UV Shift",
+        "category": "Panchroma PLA Translucent",
         "url": "https://presets.polymaker.com/"
       }
     },
@@ -4924,7 +4924,7 @@
       "position": 349,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab H2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A1 (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4938,7 +4938,7 @@
       "position": 350,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab P1P (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A1 (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4952,7 +4952,7 @@
       "position": 351,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab P1P (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A1 mini (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4966,7 +4966,7 @@
       "position": 352,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab P1S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A1 mini (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4980,7 +4980,7 @@
       "position": 353,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab P2S (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -4994,7 +4994,7 @@
       "position": 354,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab X1 (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab H2C (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5008,7 +5008,7 @@
       "position": 355,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab H2D (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5022,7 +5022,7 @@
       "position": 356,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab X2D (Bambu Studio)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab H2S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5036,7 +5036,7 @@
       "position": 357,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab P1P (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5050,7 +5050,7 @@
       "position": 358,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Prusa Core One (PrusaSlicer)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab P1P (OrcaSlicer)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5064,7 +5064,7 @@
       "position": 359,
       "item": {
         "@type": "Product",
-        "name": "Polymaker Panchroma PLA UV Shift filament preset for Snapmaker U1 (OrcaSlicer)",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab P1S (Bambu Studio)",
         "brand": {
           "@type": "Brand",
           "name": "Polymaker"
@@ -5078,6 +5078,118 @@
       "position": 360,
       "item": {
         "@type": "Product",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab P2S (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Panchroma PLA UV Shift",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 361,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab X1 (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Panchroma PLA UV Shift",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 362,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab X1 (OrcaSlicer)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Panchroma PLA UV Shift",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 363,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Bambu Lab X2D (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Panchroma PLA UV Shift",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 364,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Creality I7 (CrealityPrint)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Panchroma PLA UV Shift",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 365,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Panchroma PLA UV Shift",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 366,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Prusa Core One (PrusaSlicer)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Panchroma PLA UV Shift",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 367,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Panchroma PLA UV Shift filament preset for Snapmaker U1 (OrcaSlicer)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Panchroma PLA UV Shift",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 368,
+      "item": {
+        "@type": "Product",
         "name": "Polymaker PolyCast filament preset for Bambu Lab A2L (Bambu Studio)",
         "brand": {
           "@type": "Brand",
@@ -5089,7 +5201,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 361,
+      "position": 369,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyCast filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5103,7 +5215,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 362,
+      "position": 370,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyCast filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5117,7 +5229,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 363,
+      "position": 371,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyCast filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5131,7 +5243,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 364,
+      "position": 372,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95 filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5145,7 +5257,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 365,
+      "position": 373,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95 filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5159,7 +5271,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 366,
+      "position": 374,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95 filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -5173,7 +5285,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 367,
+      "position": 375,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95 filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5187,7 +5299,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 368,
+      "position": 376,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95 filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5201,7 +5313,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 369,
+      "position": 377,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95 filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -5215,7 +5327,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 370,
+      "position": 378,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5229,7 +5341,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 371,
+      "position": 379,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -5243,7 +5355,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 372,
+      "position": 380,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5257,7 +5369,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 373,
+      "position": 381,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyFlex TPU95-HF filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5271,7 +5383,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 374,
+      "position": 382,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite ABS filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -5285,7 +5397,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 375,
+      "position": 383,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite ABS filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5299,7 +5411,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 376,
+      "position": 384,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite ABS filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5313,7 +5425,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 377,
+      "position": 385,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite ABS filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5327,7 +5439,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 378,
+      "position": 386,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -5341,7 +5453,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 379,
+      "position": 387,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -5355,7 +5467,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 380,
+      "position": 388,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -5369,7 +5481,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 381,
+      "position": 389,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -5383,7 +5495,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 382,
+      "position": 390,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5397,7 +5509,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 383,
+      "position": 391,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -5411,7 +5523,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 384,
+      "position": 392,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -5425,7 +5537,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 385,
+      "position": 393,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5439,7 +5551,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 386,
+      "position": 394,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -5453,7 +5565,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 387,
+      "position": 395,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -5467,7 +5579,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 388,
+      "position": 396,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5481,7 +5593,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 389,
+      "position": 397,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -5495,7 +5607,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 390,
+      "position": 398,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -5509,7 +5621,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 391,
+      "position": 399,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5523,7 +5635,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 392,
+      "position": 400,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -5537,7 +5649,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 393,
+      "position": 401,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Prusa Core One (PrusaSlicer)",
@@ -5551,7 +5663,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 394,
+      "position": 402,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite CosPLA filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -5565,7 +5677,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 395,
+      "position": 403,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite LW-PLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5579,7 +5691,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 396,
+      "position": 404,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite LW-PLA filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5593,7 +5705,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 397,
+      "position": 405,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite LW-PLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5607,7 +5719,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 398,
+      "position": 406,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PC filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -5621,7 +5733,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 399,
+      "position": 407,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PC filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5635,7 +5747,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 400,
+      "position": 408,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PC filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5649,7 +5761,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 401,
+      "position": 409,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PC filament preset for Creality K2Pro (CrealityPrint)",
@@ -5663,7 +5775,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 402,
+      "position": 410,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PC filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -5677,7 +5789,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 403,
+      "position": 411,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5691,7 +5803,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 404,
+      "position": 412,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5705,7 +5817,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 405,
+      "position": 413,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5719,7 +5831,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 406,
+      "position": 414,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -5733,7 +5845,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 407,
+      "position": 415,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -5747,7 +5859,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 408,
+      "position": 416,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5761,7 +5873,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 409,
+      "position": 417,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5775,7 +5887,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 410,
+      "position": 418,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -5789,7 +5901,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 411,
+      "position": 419,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -5803,7 +5915,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 412,
+      "position": 420,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PETG Translucent filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -5817,7 +5929,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 413,
+      "position": 421,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -5831,7 +5943,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 414,
+      "position": 422,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -5845,7 +5957,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 415,
+      "position": 423,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -5859,7 +5971,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 416,
+      "position": 424,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -5873,7 +5985,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 417,
+      "position": 425,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -5887,7 +5999,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 418,
+      "position": 426,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -5901,7 +6013,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 419,
+      "position": 427,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -5915,7 +6027,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 420,
+      "position": 428,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -5929,7 +6041,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 421,
+      "position": 429,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -5943,7 +6055,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 422,
+      "position": 430,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -5957,7 +6069,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 423,
+      "position": 431,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -5971,7 +6083,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 424,
+      "position": 432,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -5985,7 +6097,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 425,
+      "position": 433,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -5999,7 +6111,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 426,
+      "position": 434,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -6013,7 +6125,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 427,
+      "position": 435,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -6027,7 +6139,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 428,
+      "position": 436,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker PolyLite PLA filament preset for Creality I7 (CrealityPrint)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyLite PLA",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 437,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -6041,7 +6167,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 429,
+      "position": 438,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Prusa Core One (PrusaSlicer)",
@@ -6055,7 +6181,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 430,
+      "position": 439,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -6069,7 +6195,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 431,
+      "position": 440,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -6083,7 +6209,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 432,
+      "position": 441,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -6097,7 +6223,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 433,
+      "position": 442,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -6111,7 +6237,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 434,
+      "position": 443,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -6125,7 +6251,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 435,
+      "position": 444,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -6139,7 +6265,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 436,
+      "position": 445,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -6153,7 +6279,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 437,
+      "position": 446,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -6167,7 +6293,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 438,
+      "position": 447,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -6181,7 +6307,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 439,
+      "position": 448,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -6195,7 +6321,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 440,
+      "position": 449,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -6209,7 +6335,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 441,
+      "position": 450,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -6223,7 +6349,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 442,
+      "position": 451,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6237,7 +6363,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 443,
+      "position": 452,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -6251,7 +6377,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 444,
+      "position": 453,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -6265,7 +6391,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 445,
+      "position": 454,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -6279,7 +6405,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 446,
+      "position": 455,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker PolyLite PLA Galaxy filament preset for Creality I7 (CrealityPrint)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyLite PLA Galaxy",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 456,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -6293,7 +6433,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 447,
+      "position": 457,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Prusa Core One (PrusaSlicer)",
@@ -6307,7 +6447,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 448,
+      "position": 458,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Galaxy filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -6321,7 +6461,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 449,
+      "position": 459,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -6335,7 +6475,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 450,
+      "position": 460,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -6349,7 +6489,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 451,
+      "position": 461,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -6363,7 +6503,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 452,
+      "position": 462,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -6377,7 +6517,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 453,
+      "position": 463,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -6391,7 +6531,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 454,
+      "position": 464,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -6405,7 +6545,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 455,
+      "position": 465,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -6419,7 +6559,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 456,
+      "position": 466,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -6433,7 +6573,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 457,
+      "position": 467,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -6447,7 +6587,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 458,
+      "position": 468,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -6461,7 +6601,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 459,
+      "position": 469,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -6475,7 +6615,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 460,
+      "position": 470,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6489,7 +6629,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 461,
+      "position": 471,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -6503,7 +6643,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 462,
+      "position": 472,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -6517,7 +6657,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 463,
+      "position": 473,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -6531,7 +6671,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 464,
+      "position": 474,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker PolyLite PLA Glow filament preset for Creality I7 (CrealityPrint)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyLite PLA Glow",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 475,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -6545,7 +6699,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 465,
+      "position": 476,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Prusa Core One (PrusaSlicer)",
@@ -6559,7 +6713,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 466,
+      "position": 477,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Glow filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -6573,7 +6727,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 467,
+      "position": 478,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -6587,7 +6741,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 468,
+      "position": 479,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -6601,7 +6755,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 469,
+      "position": 480,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -6615,7 +6769,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 470,
+      "position": 481,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -6629,7 +6783,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 471,
+      "position": 482,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -6643,7 +6797,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 472,
+      "position": 483,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -6657,7 +6811,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 473,
+      "position": 484,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -6671,7 +6825,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 474,
+      "position": 485,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -6685,7 +6839,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 475,
+      "position": 486,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -6699,7 +6853,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 476,
+      "position": 487,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -6713,7 +6867,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 477,
+      "position": 488,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -6727,7 +6881,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 478,
+      "position": 489,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6741,7 +6895,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 479,
+      "position": 490,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -6755,7 +6909,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 480,
+      "position": 491,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -6769,7 +6923,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 481,
+      "position": 492,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -6783,7 +6937,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 482,
+      "position": 493,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker PolyLite PLA Luminous filament preset for Creality I7 (CrealityPrint)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyLite PLA Luminous",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 494,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -6797,7 +6965,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 483,
+      "position": 495,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Prusa Core One (PrusaSlicer)",
@@ -6811,7 +6979,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 484,
+      "position": 496,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Luminous filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -6825,7 +6993,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 485,
+      "position": 497,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -6839,7 +7007,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 486,
+      "position": 498,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -6853,7 +7021,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 487,
+      "position": 499,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -6867,7 +7035,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 488,
+      "position": 500,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -6881,7 +7049,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 489,
+      "position": 501,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -6895,7 +7063,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 490,
+      "position": 502,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -6909,7 +7077,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 491,
+      "position": 503,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -6923,7 +7091,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 492,
+      "position": 504,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -6937,7 +7105,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 493,
+      "position": 505,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -6951,7 +7119,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 494,
+      "position": 506,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -6965,7 +7133,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 495,
+      "position": 507,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -6979,7 +7147,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 496,
+      "position": 508,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -6993,7 +7161,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 497,
+      "position": 509,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -7007,7 +7175,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 498,
+      "position": 510,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -7021,7 +7189,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 499,
+      "position": 511,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7035,7 +7203,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 500,
+      "position": 512,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker PolyLite PLA Neon filament preset for Creality I7 (CrealityPrint)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyLite PLA Neon",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 513,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -7049,7 +7231,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 501,
+      "position": 514,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Prusa Core One (PrusaSlicer)",
@@ -7063,7 +7245,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 502,
+      "position": 515,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Neon filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7077,7 +7259,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 503,
+      "position": 516,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7091,7 +7273,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 504,
+      "position": 517,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -7105,7 +7287,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 505,
+      "position": 518,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -7119,7 +7301,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 506,
+      "position": 519,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -7133,7 +7315,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 507,
+      "position": 520,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -7147,7 +7329,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 508,
+      "position": 521,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7161,7 +7343,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 509,
+      "position": 522,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -7175,7 +7357,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 510,
+      "position": 523,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Prusa Core One (PrusaSlicer)",
@@ -7189,7 +7371,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 511,
+      "position": 524,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7203,7 +7385,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 512,
+      "position": 525,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7217,7 +7399,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 513,
+      "position": 526,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -7231,7 +7413,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 514,
+      "position": 527,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -7245,7 +7427,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 515,
+      "position": 528,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -7259,7 +7441,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 516,
+      "position": 529,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -7273,7 +7455,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 517,
+      "position": 530,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7287,7 +7469,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 518,
+      "position": 531,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -7301,7 +7483,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 519,
+      "position": 532,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Prusa Core One (PrusaSlicer)",
@@ -7315,7 +7497,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 520,
+      "position": 533,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Pro Metallic filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7329,7 +7511,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 521,
+      "position": 534,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -7343,7 +7525,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 522,
+      "position": 535,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -7357,7 +7539,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 523,
+      "position": 536,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -7371,7 +7553,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 524,
+      "position": 537,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -7385,7 +7567,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 525,
+      "position": 538,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7399,7 +7581,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 526,
+      "position": 539,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -7413,7 +7595,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 527,
+      "position": 540,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -7427,7 +7609,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 528,
+      "position": 541,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -7441,7 +7623,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 529,
+      "position": 542,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -7455,7 +7637,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 530,
+      "position": 543,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -7469,7 +7651,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 531,
+      "position": 544,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -7483,7 +7665,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 532,
+      "position": 545,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -7497,7 +7679,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 533,
+      "position": 546,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -7511,7 +7693,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 534,
+      "position": 547,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -7525,7 +7707,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 535,
+      "position": 548,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7539,7 +7721,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 536,
+      "position": 549,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker PolyLite PLA Starlight filament preset for Creality I7 (CrealityPrint)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyLite PLA Starlight",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 550,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -7553,7 +7749,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 537,
+      "position": 551,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Prusa Core One (PrusaSlicer)",
@@ -7567,7 +7763,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 538,
+      "position": 552,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Starlight filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7581,7 +7777,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 539,
+      "position": 553,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -7595,7 +7791,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 540,
+      "position": 554,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -7609,7 +7805,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 541,
+      "position": 555,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -7623,7 +7819,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 542,
+      "position": 556,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -7637,7 +7833,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 543,
+      "position": 557,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7651,7 +7847,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 544,
+      "position": 558,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -7665,7 +7861,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 545,
+      "position": 559,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -7679,7 +7875,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 546,
+      "position": 560,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -7693,7 +7889,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 547,
+      "position": 561,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -7707,7 +7903,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 548,
+      "position": 562,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -7721,7 +7917,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 549,
+      "position": 563,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -7735,7 +7931,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 550,
+      "position": 564,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -7749,7 +7945,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 551,
+      "position": 565,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -7763,7 +7959,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 552,
+      "position": 566,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -7777,7 +7973,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 553,
+      "position": 567,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7791,7 +7987,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 554,
+      "position": 568,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker PolyLite PLA Translucent filament preset for Creality I7 (CrealityPrint)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "PolyLite PLA Translucent",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 569,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -7805,7 +8015,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 555,
+      "position": 570,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Prusa Core One (PrusaSlicer)",
@@ -7819,7 +8029,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 556,
+      "position": 571,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA Translucent filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7833,7 +8043,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 557,
+      "position": 572,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA-CF filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7847,7 +8057,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 558,
+      "position": 573,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA-CF filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -7861,7 +8071,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 559,
+      "position": 574,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA-CF filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7875,7 +8085,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 560,
+      "position": 575,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyLite PLA-CF filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -7889,7 +8099,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 561,
+      "position": 576,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PC filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -7903,7 +8113,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 562,
+      "position": 577,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PC filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -7917,7 +8127,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 563,
+      "position": 578,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PC filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -7931,7 +8141,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 564,
+      "position": 579,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PC filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -7945,7 +8155,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 565,
+      "position": 580,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PETG filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -7959,7 +8169,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 566,
+      "position": 581,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PETG filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -7973,7 +8183,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 567,
+      "position": 582,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PETG filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -7987,7 +8197,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 568,
+      "position": 583,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PETG filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8001,7 +8211,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 569,
+      "position": 584,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PETG filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8015,7 +8225,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 570,
+      "position": 585,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PETG filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8029,7 +8239,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 571,
+      "position": 586,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -8043,7 +8253,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 572,
+      "position": 587,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PLA filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -8057,7 +8267,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 573,
+      "position": 588,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PLA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -8071,7 +8281,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 574,
+      "position": 589,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PLA filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8085,7 +8295,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 575,
+      "position": 590,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PLA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8099,7 +8309,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 576,
+      "position": 591,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8113,7 +8323,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 577,
+      "position": 592,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8127,7 +8337,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 578,
+      "position": 593,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyMax PLA filament preset for Prusa Core One (PrusaSlicer)",
@@ -8141,7 +8351,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 579,
+      "position": 594,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySmooth filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -8155,7 +8365,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 580,
+      "position": 595,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySmooth filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8169,7 +8379,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 581,
+      "position": 596,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySmooth filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8183,7 +8393,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 582,
+      "position": 597,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySupport filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -8197,7 +8407,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 583,
+      "position": 598,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySupport filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8211,7 +8421,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 584,
+      "position": 599,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySupport filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8225,7 +8435,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 585,
+      "position": 600,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySupport for PA12 filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8239,7 +8449,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 586,
+      "position": 601,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySupport for PA12 filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8253,7 +8463,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 587,
+      "position": 602,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolySupport for PA12 filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8267,7 +8477,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 588,
+      "position": 603,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -8281,7 +8491,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 589,
+      "position": 604,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -8295,7 +8505,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 590,
+      "position": 605,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -8309,7 +8519,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 591,
+      "position": 606,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -8323,7 +8533,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 592,
+      "position": 607,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -8337,7 +8547,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 593,
+      "position": 608,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -8351,7 +8561,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 594,
+      "position": 609,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -8365,7 +8575,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 595,
+      "position": 610,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -8379,7 +8589,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 596,
+      "position": 611,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -8393,7 +8603,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 597,
+      "position": 612,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8407,7 +8617,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 598,
+      "position": 613,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -8421,7 +8631,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 599,
+      "position": 614,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -8435,7 +8645,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 600,
+      "position": 615,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8449,7 +8659,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 601,
+      "position": 616,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8463,7 +8673,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 602,
+      "position": 617,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Prusa Core One (PrusaSlicer)",
@@ -8477,7 +8687,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 603,
+      "position": 618,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -8491,7 +8701,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 604,
+      "position": 619,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -8505,7 +8715,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 605,
+      "position": 620,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -8519,7 +8729,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 606,
+      "position": 621,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -8533,7 +8743,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 607,
+      "position": 622,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -8547,7 +8757,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 608,
+      "position": 623,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -8561,7 +8771,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 609,
+      "position": 624,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -8575,7 +8785,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 610,
+      "position": 625,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -8589,7 +8799,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 611,
+      "position": 626,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -8603,7 +8813,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 612,
+      "position": 627,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -8617,7 +8827,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 613,
+      "position": 628,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8631,7 +8841,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 614,
+      "position": 629,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -8645,7 +8855,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 615,
+      "position": 630,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -8659,7 +8869,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 616,
+      "position": 631,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8673,7 +8883,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 617,
+      "position": 632,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8687,7 +8897,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 618,
+      "position": 633,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Prusa Core One (PrusaSlicer)",
@@ -8701,7 +8911,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 619,
+      "position": 634,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA Marble filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -8715,7 +8925,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 620,
+      "position": 635,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -8729,7 +8939,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 621,
+      "position": 636,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab A1 (OrcaSlicer)",
@@ -8743,7 +8953,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 622,
+      "position": 637,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab A1 mini (Bambu Studio)",
@@ -8757,7 +8967,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 623,
+      "position": 638,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab A1 mini (OrcaSlicer)",
@@ -8771,7 +8981,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 624,
+      "position": 639,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -8785,7 +8995,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 625,
+      "position": 640,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8799,7 +9009,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 626,
+      "position": 641,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab P1P (Bambu Studio)",
@@ -8813,7 +9023,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 627,
+      "position": 642,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab P1P (OrcaSlicer)",
@@ -8827,7 +9037,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 628,
+      "position": 643,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8841,7 +9051,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 629,
+      "position": 644,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab X1 (Bambu Studio)",
@@ -8855,7 +9065,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 630,
+      "position": 645,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab X1 (OrcaSlicer)",
@@ -8869,7 +9079,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 631,
+      "position": 646,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8883,7 +9093,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 632,
+      "position": 647,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -8897,7 +9107,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 633,
+      "position": 648,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Prusa Core One (PrusaSlicer)",
@@ -8911,7 +9121,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 634,
+      "position": 649,
       "item": {
         "@type": "Product",
         "name": "Polymaker PolyTerra PLA+ filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -8925,7 +9135,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 635,
+      "position": 650,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Polylite ASA for TYC Americas filament preset for Bambu Lab H2C (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Polylite ASA for TYC Americas",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 651,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polylite ASA for TYC Americas filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -8939,7 +9163,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 636,
+      "position": 652,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polylite ASA for TYC Americas filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -8953,7 +9177,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 637,
+      "position": 653,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polylite ASA for TYC Americas filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -8967,7 +9191,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 638,
+      "position": 654,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polylite ASA for TYC Americas filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -8981,7 +9205,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 639,
+      "position": 655,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polylite ASA for TYC Americas filament preset for Creality K2Pro (CrealityPrint)",
@@ -8995,7 +9219,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 640,
+      "position": 656,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -9009,7 +9233,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 641,
+      "position": 657,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -9023,7 +9247,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 642,
+      "position": 658,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -9037,7 +9261,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 643,
+      "position": 659,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -9051,7 +9275,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 644,
+      "position": 660,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -9065,7 +9289,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 645,
+      "position": 661,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -9079,7 +9303,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 646,
+      "position": 662,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Creality K2Pro (CrealityPrint)",
@@ -9093,7 +9317,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 647,
+      "position": 663,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -9107,7 +9331,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 648,
+      "position": 664,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Max filament preset for QIDI Q2 (OrcaSlicer)",
@@ -9121,7 +9345,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 649,
+      "position": 665,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Anycubic Kobra S1 (OrcaSlicer)",
@@ -9135,7 +9359,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 650,
+      "position": 666,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -9149,7 +9373,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 651,
+      "position": 667,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -9163,7 +9387,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 652,
+      "position": 668,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -9177,7 +9401,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 653,
+      "position": 669,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -9191,7 +9415,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 654,
+      "position": 670,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -9205,7 +9429,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 655,
+      "position": 671,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -9219,7 +9443,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 656,
+      "position": 672,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Creality K2Pro (CrealityPrint)",
@@ -9233,7 +9457,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 657,
+      "position": 673,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -9247,7 +9471,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 658,
+      "position": 674,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -9261,7 +9485,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 659,
+      "position": 675,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Anycubic Kobra S1 (OrcaSlicer)",
@@ -9275,7 +9499,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 660,
+      "position": 676,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -9289,7 +9513,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 661,
+      "position": 677,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -9303,7 +9527,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 662,
+      "position": 678,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -9317,7 +9541,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 663,
+      "position": 679,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -9331,7 +9555,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 664,
+      "position": 680,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -9345,7 +9569,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 665,
+      "position": 681,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -9359,7 +9583,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 666,
+      "position": 682,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Creality K2Pro (CrealityPrint)",
@@ -9373,7 +9597,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 667,
+      "position": 683,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -9387,7 +9611,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 668,
+      "position": 684,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ABS Pro Galaxy filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -9401,7 +9625,21 @@
     },
     {
       "@type": "ListItem",
-      "position": 669,
+      "position": 685,
+      "item": {
+        "@type": "Product",
+        "name": "Polymaker Polymaker ASA filament preset for Bambu Lab H2C (Bambu Studio)",
+        "brand": {
+          "@type": "Brand",
+          "name": "Polymaker"
+        },
+        "category": "Polymaker ASA",
+        "url": "https://presets.polymaker.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 686,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ASA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -9415,7 +9653,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 670,
+      "position": 687,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ASA filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -9429,7 +9667,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 671,
+      "position": 688,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ASA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -9443,7 +9681,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 672,
+      "position": 689,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ASA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -9457,7 +9695,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 673,
+      "position": 690,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker ASA filament preset for Creality K2Pro (CrealityPrint)",
@@ -9471,7 +9709,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 674,
+      "position": 691,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -9485,7 +9723,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 675,
+      "position": 692,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -9499,7 +9737,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 676,
+      "position": 693,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -9513,7 +9751,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 677,
+      "position": 694,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -9527,7 +9765,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 678,
+      "position": 695,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -9541,7 +9779,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 679,
+      "position": 696,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -9555,7 +9793,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 680,
+      "position": 697,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -9569,7 +9807,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 681,
+      "position": 698,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -9583,7 +9821,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 682,
+      "position": 699,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Prusa Core One (PrusaSlicer)",
@@ -9597,7 +9835,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 683,
+      "position": 700,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -9611,7 +9849,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 684,
+      "position": 701,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Anycubic Kobra S1 (OrcaSlicer)",
@@ -9625,7 +9863,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 685,
+      "position": 702,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -9639,7 +9877,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 686,
+      "position": 703,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -9653,7 +9891,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 687,
+      "position": 704,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -9667,7 +9905,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 688,
+      "position": 705,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -9681,7 +9919,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 689,
+      "position": 706,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -9695,7 +9933,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 690,
+      "position": 707,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -9709,7 +9947,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 691,
+      "position": 708,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -9723,7 +9961,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 692,
+      "position": 709,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -9737,7 +9975,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 693,
+      "position": 710,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Creality I7 (CrealityPrint)",
@@ -9751,7 +9989,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 694,
+      "position": 711,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Creality K2Pro (CrealityPrint)",
@@ -9765,7 +10003,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 695,
+      "position": 712,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -9779,7 +10017,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 696,
+      "position": 713,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for QIDI Q2 (OrcaSlicer)",
@@ -9793,7 +10031,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 697,
+      "position": 714,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA Pro filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -9807,7 +10045,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 698,
+      "position": 715,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -9821,7 +10059,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 699,
+      "position": 716,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -9835,7 +10073,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 700,
+      "position": 717,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -9849,7 +10087,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 701,
+      "position": 718,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -9863,7 +10101,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 702,
+      "position": 719,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -9877,7 +10115,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 703,
+      "position": 720,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA-GF filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -9891,7 +10129,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 704,
+      "position": 721,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA-GF filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -9905,7 +10143,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 705,
+      "position": 722,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA-GF filament preset for Prusa Core One (PrusaSlicer)",
@@ -9919,7 +10157,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 706,
+      "position": 723,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker HT-PLA-GF filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -9933,7 +10171,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 707,
+      "position": 724,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -9947,7 +10185,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 708,
+      "position": 725,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -9961,7 +10199,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 709,
+      "position": 726,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -9975,7 +10213,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 710,
+      "position": 727,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -9989,7 +10227,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 711,
+      "position": 728,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -10003,7 +10241,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 712,
+      "position": 729,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -10017,7 +10255,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 713,
+      "position": 730,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -10031,7 +10269,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 714,
+      "position": 731,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -10045,7 +10283,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 715,
+      "position": 732,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -10059,7 +10297,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 716,
+      "position": 733,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Prusa Core One (PrusaSlicer)",
@@ -10073,7 +10311,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 717,
+      "position": 734,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -10087,7 +10325,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 718,
+      "position": 735,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -10101,7 +10339,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 719,
+      "position": 736,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -10115,7 +10353,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 720,
+      "position": 737,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -10129,7 +10367,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 721,
+      "position": 738,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -10143,7 +10381,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 722,
+      "position": 739,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -10157,7 +10395,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 723,
+      "position": 740,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -10171,7 +10409,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 724,
+      "position": 741,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -10185,7 +10423,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 725,
+      "position": 742,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -10199,7 +10437,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 726,
+      "position": 743,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -10213,7 +10451,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 727,
+      "position": 744,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Prusa Core One (PrusaSlicer)",
@@ -10227,7 +10465,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 728,
+      "position": 745,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PETG Galaxy filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -10241,7 +10479,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 729,
+      "position": 746,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -10255,7 +10493,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 730,
+      "position": 747,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -10269,7 +10507,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 731,
+      "position": 748,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -10283,7 +10521,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 732,
+      "position": 749,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -10297,7 +10535,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 733,
+      "position": 750,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -10311,7 +10549,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 734,
+      "position": 751,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -10325,7 +10563,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 735,
+      "position": 752,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -10339,7 +10577,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 736,
+      "position": 753,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -10353,7 +10591,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 737,
+      "position": 754,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Prusa Core One (PrusaSlicer)",
@@ -10367,7 +10605,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 738,
+      "position": 755,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -10381,7 +10619,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 739,
+      "position": 756,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Anycubic Kobra S1 (OrcaSlicer)",
@@ -10395,7 +10633,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 740,
+      "position": 757,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -10409,7 +10647,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 741,
+      "position": 758,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -10423,7 +10661,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 742,
+      "position": 759,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -10437,7 +10675,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 743,
+      "position": 760,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -10451,7 +10689,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 744,
+      "position": 761,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -10465,7 +10703,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 745,
+      "position": 762,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -10479,7 +10717,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 746,
+      "position": 763,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -10493,7 +10731,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 747,
+      "position": 764,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -10507,7 +10745,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 748,
+      "position": 765,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -10521,7 +10759,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 749,
+      "position": 766,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Prusa Core One (PrusaSlicer)",
@@ -10535,7 +10773,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 750,
+      "position": 767,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -10549,7 +10787,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 751,
+      "position": 768,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Anycubic Kobra S1 (OrcaSlicer)",
@@ -10563,7 +10801,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 752,
+      "position": 769,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab A1 (Bambu Studio)",
@@ -10577,7 +10815,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 753,
+      "position": 770,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab A2L (Bambu Studio)",
@@ -10591,7 +10829,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 754,
+      "position": 771,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab H2C (Bambu Studio)",
@@ -10605,7 +10843,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 755,
+      "position": 772,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab H2D (Bambu Studio)",
@@ -10619,7 +10857,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 756,
+      "position": 773,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab H2S (Bambu Studio)",
@@ -10633,7 +10871,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 757,
+      "position": 774,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab P1S (Bambu Studio)",
@@ -10647,7 +10885,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 758,
+      "position": 775,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab P2S (Bambu Studio)",
@@ -10661,7 +10899,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 759,
+      "position": 776,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Bambu Lab X2D (Bambu Studio)",
@@ -10675,7 +10913,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 760,
+      "position": 777,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Elegoo Centauri Carbon 2 (ElegooSlicer)",
@@ -10689,7 +10927,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 761,
+      "position": 778,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Prusa Core One (PrusaSlicer)",
@@ -10703,7 +10941,7 @@
     },
     {
       "@type": "ListItem",
-      "position": 762,
+      "position": 779,
       "item": {
         "@type": "Product",
         "name": "Polymaker Polymaker PLA Pro Metallic filament preset for Snapmaker U1 (OrcaSlicer)",
@@ -10978,7 +11216,7 @@
     <noscript>
     <section class="card seo-content" id="about-presets" aria-labelledby="about-presets-title">
       <h2 id="about-presets-title" class="seo-content-title">Polymaker filament presets for Bambu Studio, OrcaSlicer, ElegooSlicer &amp; PrusaSlicer</h2>
-      <p>Download free, official Polymaker print profiles and 3D printing filament presets. This page provides 762 ready-to-use presets covering 68 Polymaker materials, tuned for Bambu Studio, CrealityPrint, ElegooSlicer, OrcaSlicer, PrusaSlicer. Each preset sets the recommended nozzle and bed temperature, flow rate, cooling, and other parameters so your Polymaker filament prints correctly on the first try.</p>
+      <p>Download free, official Polymaker print profiles and 3D printing filament presets. This page provides 779 ready-to-use presets covering 68 Polymaker materials, tuned for Bambu Studio, CrealityPrint, ElegooSlicer, OrcaSlicer, PrusaSlicer. Each preset sets the recommended nozzle and bed temperature, flow rate, cooling, and other parameters so your Polymaker filament prints correctly on the first try.</p>
       <p>Presets are organized by slicer, material, printer brand, and printer model. Whether you need a PolyLite PETG preset for the Bambu Lab X1 Carbon, a Fiberon ASA-CF preset for Bambu Studio, or a PolyTerra PLA profile for OrcaSlicer, use the filters above to download the exact preset file for your printer.</p>
 
       <h3 class="seo-section-title">Materials with presets</h3>

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updatedAt": "2026-08-25T01:55:37.580Z",
+  "updatedAt": "2026-08-25T01:57:13.525Z",
   "materials": [
     "Fiberon ASA-CF08",
     "Fiberon PA12-CF10",

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updatedAt": "2026-08-14T05:59:40.784Z",
+  "updatedAt": "2026-08-25T01:55:37.580Z",
   "materials": [
     "Fiberon ASA-CF08",
     "Fiberon PA12-CF10",
@@ -116,7 +116,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon ASA-CF08/BBL/H2C/BambuStudio/Fiberon ASA-CF08 @BBL H2C.json",
       "filename": "Fiberon ASA-CF08 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -135,7 +135,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon ASA-CF08/BBL/H2D/BambuStudio/Fiberon ASA-CF08 @BBL H2D.json",
       "filename": "Fiberon ASA-CF08 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -154,7 +154,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon ASA-CF08/BBL/H2S/BambuStudio/Fiberon ASA-CF08 @BBL H2S.json",
       "filename": "Fiberon ASA-CF08 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -173,7 +173,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon ASA-CF08/BBL/P2S/BambuStudio/Fiberon ASA-CF08 @BBL P2S.json",
       "filename": "Fiberon ASA-CF08 @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -192,7 +192,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon ASA-CF08/BBL/X2D/BambuStudio/Fiberon ASA-CF08 @BBL X2D.json",
       "filename": "Fiberon ASA-CF08 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -255,7 +255,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA12-CF10/BBL/H2C/BambuStudio/Fiberon PA12-CF10 @BBL H2C.json",
       "filename": "Fiberon PA12-CF10 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -271,7 +271,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA12-CF10/BBL/H2D/BambuStudio/Fiberon PA12-CF10 @BBL H2D.json",
       "filename": "Fiberon PA12-CF10 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -287,7 +287,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA12-CF10/BBL/H2S/BambuStudio/Fiberon PA12-CF10 @BBL H2S.json",
       "filename": "Fiberon PA12-CF10 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -306,7 +306,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA12-CF10/BBL/P2S/BambuStudio/Fiberon PA12-CF10 @BBL P2S.json",
       "filename": "Fiberon PA12-CF10 @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -325,7 +325,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA12-CF10/BBL/X1/BambuStudio/Fiberon PA12-CF10 @BBL X1.json",
       "filename": "Fiberon PA12-CF10 @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -387,7 +387,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA12-CF10/BBL/X2D/BambuStudio/Fiberon PA12-CF10 @BBL X2D.json",
       "filename": "Fiberon PA12-CF10 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -456,7 +456,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-CF20/BBL/H2C/BambuStudio/Fiberon PA6-CF20 @BBL H2C.json",
       "filename": "Fiberon PA6-CF20 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -475,7 +475,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-CF20/BBL/H2D/BambuStudio/Fiberon PA6-CF20 @BBL H2D.json",
       "filename": "Fiberon PA6-CF20 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -494,7 +494,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-CF20/BBL/H2S/BambuStudio/Fiberon PA6-CF20 @BBL H2S.json",
       "filename": "Fiberon PA6-CF20 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -513,7 +513,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-CF20/BBL/P2S/BambuStudio/Fiberon PA6-CF20 @BBL P2S.json",
       "filename": "Fiberon PA6-CF20 @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -532,7 +532,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-CF20/BBL/X1/BambuStudio/Fiberon PA6-CF20 @BBL X1.json",
       "filename": "Fiberon PA6-CF20 @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -594,7 +594,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-CF20/BBL/X2D/BambuStudio/Fiberon PA6-CF20 @BBL X2D.json",
       "filename": "Fiberon PA6-CF20 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -642,7 +642,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-GF25/BBL/H2C/BambuStudio/Fiberon PA6-GF25 @BBL H2C.json",
       "filename": "Fiberon PA6-GF25 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -661,7 +661,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-GF25/BBL/H2D/BambuStudio/Fiberon PA6-GF25 @BBL H2D.json",
       "filename": "Fiberon PA6-GF25 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -680,7 +680,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-GF25/BBL/H2S/BambuStudio/Fiberon PA6-GF25 @BBL H2S.json",
       "filename": "Fiberon PA6-GF25 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -699,7 +699,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-GF25/BBL/P2S/BambuStudio/Fiberon PA6-GF25 @BBL P2S.json",
       "filename": "Fiberon PA6-GF25 @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -718,7 +718,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-GF25/BBL/X1/BambuStudio/Fiberon PA6-GF25 @BBL X1.json",
       "filename": "Fiberon PA6-GF25 @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -780,7 +780,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA6-GF25/BBL/X2D/BambuStudio/Fiberon PA6-GF25 @BBL X2D.json",
       "filename": "Fiberon PA6-GF25 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -833,7 +833,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-CF15/BBL/H2C/BambuStudio/Fiberon PA612-CF15 @BBL H2C.json",
       "filename": "Fiberon PA612-CF15 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -849,7 +849,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-CF15/BBL/H2D/BambuStudio/Fiberon PA612-CF15 @BBL H2D.json",
       "filename": "Fiberon PA612-CF15 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -865,7 +865,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-CF15/BBL/H2S/BambuStudio/Fiberon PA612-CF15 @BBL H2S.json",
       "filename": "Fiberon PA612-CF15 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -884,7 +884,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-CF15/BBL/P2S/BambuStudio/Fiberon PA612-CF15 @BBL P2S.json",
       "filename": "Fiberon PA612-CF15 @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -903,7 +903,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-CF15/BBL/X1/BambuStudio/Fiberon PA612-CF15 @BBL X1.json",
       "filename": "Fiberon PA612-CF15 @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -965,7 +965,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-CF15/BBL/X2D/BambuStudio/Fiberon PA612-CF15 @BBL X2D.json",
       "filename": "Fiberon PA612-CF15 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1013,7 +1013,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-ESD/BBL/H2C/BambuStudio/Fiberon PA612-ESD @BBL H2C.json",
       "filename": "Fiberon PA612-ESD @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1029,7 +1029,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-ESD/BBL/H2D/BambuStudio/Fiberon PA612-ESD @BBL H2D.json",
       "filename": "Fiberon PA612-ESD @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1048,7 +1048,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-ESD/BBL/H2S/BambuStudio/Fiberon PA612-ESD @BBL H2S.json",
       "filename": "Fiberon PA612-ESD @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1067,7 +1067,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-ESD/BBL/P2S/BambuStudio/Fiberon PA612-ESD @BBL P2S.json",
       "filename": "Fiberon PA612-ESD @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1086,7 +1086,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PA612-ESD/BBL/X2D/BambuStudio/Fiberon PA612-ESD @BBL X2D.json",
       "filename": "Fiberon PA612-ESD @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1134,7 +1134,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-CF17/BBL/H2C/BambuStudio/Fiberon PET-CF17 @BBL H2C.json",
       "filename": "Fiberon PET-CF17 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1150,7 +1150,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-CF17/BBL/H2D/BambuStudio/Fiberon PET-CF17 @BBL H2D.json",
       "filename": "Fiberon PET-CF17 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1169,7 +1169,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-CF17/BBL/H2S/BambuStudio/Fiberon PET-CF17 @BBL H2S.json",
       "filename": "Fiberon PET-CF17 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1188,7 +1188,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-CF17/BBL/P2S/BambuStudio/Fiberon PET-CF17 @BBL P2S.json",
       "filename": "Fiberon PET-CF17 @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1204,7 +1204,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-CF17/BBL/X1/BambuStudio/Fiberon PET-CF17 @BBL X1.json",
       "filename": "Fiberon PET-CF17 @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1266,7 +1266,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-CF17/BBL/X2D/BambuStudio/Fiberon PET-CF17 @BBL X2D.json",
       "filename": "Fiberon PET-CF17 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1314,7 +1314,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-GF15/BBL/H2C/BambuStudio/Fiberon PET-GF15 @BBL H2C.json",
       "filename": "Fiberon PET-GF15 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1333,7 +1333,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-GF15/BBL/H2D/BambuStudio/Fiberon PET-GF15 @BBL H2D.json",
       "filename": "Fiberon PET-GF15 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1352,7 +1352,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-GF15/BBL/H2S/BambuStudio/Fiberon PET-GF15 @BBL H2S.json",
       "filename": "Fiberon PET-GF15 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1371,7 +1371,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-GF15/BBL/P2S/BambuStudio/Fiberon PET-GF15 @BBL P2S.json",
       "filename": "Fiberon PET-GF15 @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1387,7 +1387,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PET-GF15/BBL/X2D/BambuStudio/Fiberon PET-GF15 @BBL X2D.json",
       "filename": "Fiberon PET-GF15 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1440,7 +1440,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-ESD/BBL/A2L/BambuStudio/Fiberon PETG-ESD @BBL A2L.json",
       "filename": "Fiberon PETG-ESD @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1456,7 +1456,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-ESD/BBL/H2C/BambuStudio/Fiberon PETG-ESD @BBL H2C.json",
       "filename": "Fiberon PETG-ESD @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1475,7 +1475,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-ESD/BBL/H2D/BambuStudio/Fiberon PETG-ESD @BBL H2D.json",
       "filename": "Fiberon PETG-ESD @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1494,7 +1494,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-ESD/BBL/P2S/BambuStudio/Fiberon PETG-ESD @BBL P2S.json",
       "filename": "Fiberon PETG-ESD @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1513,7 +1513,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-ESD/BBL/X1/BambuStudio/Fiberon PETG-ESD @BBL X1.json",
       "filename": "Fiberon PETG-ESD @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1575,7 +1575,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-ESD/BBL/X2D/BambuStudio/Fiberon PETG-ESD @BBL X2D.json",
       "filename": "Fiberon PETG-ESD @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1628,7 +1628,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-rCF08/BBL/A2L/BambuStudio/Fiberon PETG-rCF08 @BBL A2L.json",
       "filename": "Fiberon PETG-rCF08 @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1644,7 +1644,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-rCF08/BBL/H2C/BambuStudio/Fiberon PETG-rCF08 @BBL H2C.json",
       "filename": "Fiberon PETG-rCF08 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1663,7 +1663,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-rCF08/BBL/H2D/BambuStudio/Fiberon PETG-rCF08 @BBL H2D.json",
       "filename": "Fiberon PETG-rCF08 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1682,7 +1682,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-rCF08/BBL/H2S/BambuStudio/Fiberon PETG-rCF08 @BBL H2S.json",
       "filename": "Fiberon PETG-rCF08 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1701,7 +1701,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-rCF08/BBL/X1/BambuStudio/Fiberon PETG-rCF08 @BBL X1.json",
       "filename": "Fiberon PETG-rCF08 @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1763,7 +1763,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PETG-rCF08/BBL/X2D/BambuStudio/Fiberon PETG-rCF08 @BBL X2D.json",
       "filename": "Fiberon PETG-rCF08 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1800,7 +1800,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PPS-CF10/BBL/H2C/BambuStudio/Fiberon PPS-CF10 @BBL H2C.json",
       "filename": "Fiberon PPS-CF10 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1819,7 +1819,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PPS-CF10/BBL/H2D/BambuStudio/Fiberon PPS-CF10 @BBL H2D.json",
       "filename": "Fiberon PPS-CF10 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1838,7 +1838,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PPS-CF10/BBL/H2S/BambuStudio/Fiberon PPS-CF10 @BBL H2S.json",
       "filename": "Fiberon PPS-CF10 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1854,7 +1854,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PPS-GF20/BBL/H2C/BambuStudio/Fiberon PPS-GF20 @BBL H2C.json",
       "filename": "Fiberon PPS-GF20 @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1873,7 +1873,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PPS-GF20/BBL/H2D/BambuStudio/Fiberon PPS-GF20 @BBL H2D.json",
       "filename": "Fiberon PPS-GF20 @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1892,7 +1892,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Fiberon PPS-GF20/BBL/H2S/BambuStudio/Fiberon PPS-GF20 @BBL H2S.json",
       "filename": "Fiberon PPS-GF20 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1927,7 +1927,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/A1/BambuStudio/Panchroma CoPE @BBL A1.json",
       "filename": "Panchroma CoPE @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -1969,7 +1969,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/A1M/BambuStudio/Panchroma CoPE @BBL A1M.json",
       "filename": "Panchroma CoPE @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2011,7 +2011,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/A2L/BambuStudio/Panchroma CoPE @BBL A2L.json",
       "filename": "Panchroma CoPE @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2027,7 +2027,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/H2C/BambuStudio/Panchroma CoPE @BBL H2C.json",
       "filename": "Panchroma CoPE @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2043,7 +2043,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/H2D/BambuStudio/Panchroma CoPE @BBL H2D.json",
       "filename": "Panchroma CoPE @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2059,7 +2059,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/H2S/BambuStudio/Panchroma CoPE @BBL H2S.json",
       "filename": "Panchroma CoPE @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2078,7 +2078,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/P1P/BambuStudio/Panchroma CoPE @BBL P1P.json",
       "filename": "Panchroma CoPE @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2110,7 +2110,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/P2S/BambuStudio/Panchroma CoPE @BBL P2S.json",
       "filename": "Panchroma CoPE @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2126,7 +2126,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/X1/BambuStudio/Panchroma CoPE @BBL X1.json",
       "filename": "Panchroma CoPE @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2188,7 +2188,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma CoPE/BBL/X2D/BambuStudio/Panchroma CoPE @BBL X2D.json",
       "filename": "Panchroma CoPE @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2262,7 +2262,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/A1/BambuStudio/Panchroma PLA @BBL A1.json",
       "filename": "Panchroma PLA @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2304,7 +2304,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/A1M/BambuStudio/Panchroma PLA @BBL A1M.json",
       "filename": "Panchroma PLA @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2346,7 +2346,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/A2L/BambuStudio/Panchroma PLA @BBL A2L.json",
       "filename": "Panchroma PLA @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2362,7 +2362,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/H2C/BambuStudio/Panchroma PLA @BBL H2C.json",
       "filename": "Panchroma PLA @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2381,7 +2381,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/H2D/BambuStudio/Panchroma PLA @BBL H2D.json",
       "filename": "Panchroma PLA @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2397,7 +2397,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/H2S/BambuStudio/Panchroma PLA @BBL H2S.json",
       "filename": "Panchroma PLA @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2413,7 +2413,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/P1P/BambuStudio/Panchroma PLA @BBL P1P.json",
       "filename": "Panchroma PLA @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2445,7 +2445,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/P1S/BambuStudio/Panchroma PLA @BBL P1S.json",
       "filename": "Panchroma PLA @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2476,7 +2476,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/P2S/BambuStudio/Panchroma PLA @BBL P2S.json",
       "filename": "Panchroma PLA @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2492,7 +2492,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/X1/BambuStudio/Panchroma PLA @BBL X1.json",
       "filename": "Panchroma PLA @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2554,7 +2554,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA/BBL/X2D/BambuStudio/Panchroma PLA @BBL X2D.json",
       "filename": "Panchroma PLA @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2591,7 +2591,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Panchroma PLA/Elegoo/CC2/ElegooSlicer/Panchroma PLA @Elegoo CC2.json",
       "filename": "Panchroma PLA @Elegoo CC2.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -2607,7 +2607,7 @@
       "slicer": "PrusaSlicer",
       "path": "preset/Panchroma PLA/Prusa/Core One/PrusaSlicer/Panchroma PLA @Prusa Core One.ini",
       "filename": "Panchroma PLA @Prusa Core One.ini",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": []
     },
     {
@@ -2633,7 +2633,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/A1/BambuStudio/Panchroma PLA Celestial @BBL A1.json",
       "filename": "Panchroma PLA Celestial @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2675,7 +2675,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/A1M/BambuStudio/Panchroma PLA Celestial @BBL A1M.json",
       "filename": "Panchroma PLA Celestial @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2717,7 +2717,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/A2L/BambuStudio/Panchroma PLA Celestial @BBL A2L.json",
       "filename": "Panchroma PLA Celestial @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2733,7 +2733,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/H2C/BambuStudio/Panchroma PLA Celestial @BBL H2C.json",
       "filename": "Panchroma PLA Celestial @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2749,7 +2749,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/H2D/BambuStudio/Panchroma PLA Celestial @BBL H2D.json",
       "filename": "Panchroma PLA Celestial @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2765,7 +2765,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/H2S/BambuStudio/Panchroma PLA Celestial @BBL H2S.json",
       "filename": "Panchroma PLA Celestial @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2781,7 +2781,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/P1P/BambuStudio/Panchroma PLA Celestial @BBL P1P.json",
       "filename": "Panchroma PLA Celestial @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2813,7 +2813,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/P1S/BambuStudio/Panchroma PLA Celestial @BBL P1S.json",
       "filename": "Panchroma PLA Celestial @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2844,7 +2844,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/P2S/BambuStudio/Panchroma PLA Celestial @BBL P2S.json",
       "filename": "Panchroma PLA Celestial @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2860,7 +2860,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/X1/BambuStudio/Panchroma PLA Celestial @BBL X1.json",
       "filename": "Panchroma PLA Celestial @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -2922,12 +2922,28 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Celestial/BBL/X2D/BambuStudio/Panchroma PLA Celestial @BBL X2D.json",
       "filename": "Panchroma PLA Celestial @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Panchroma PLA Celestial",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/Panchroma PLA Celestial/Creality/I7/CrealityPrint/Panchroma PLA Celestial @Creality I7.json",
+      "filename": "Panchroma PLA Celestial @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -2980,7 +2996,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/A1/BambuStudio/Panchroma PLA Galaxy @BBL A1.json",
       "filename": "Panchroma PLA Galaxy @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3022,7 +3038,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/A1M/BambuStudio/Panchroma PLA Galaxy @BBL A1M.json",
       "filename": "Panchroma PLA Galaxy @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3064,7 +3080,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/A2L/BambuStudio/Panchroma PLA Galaxy @BBL A2L.json",
       "filename": "Panchroma PLA Galaxy @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3080,7 +3096,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/H2C/BambuStudio/Panchroma PLA Galaxy @BBL H2C.json",
       "filename": "Panchroma PLA Galaxy @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3096,7 +3112,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/H2D/BambuStudio/Panchroma PLA Galaxy @BBL H2D.json",
       "filename": "Panchroma PLA Galaxy @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3112,7 +3128,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/H2S/BambuStudio/Panchroma PLA Galaxy @BBL H2S.json",
       "filename": "Panchroma PLA Galaxy @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3128,7 +3144,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/P1P/BambuStudio/Panchroma PLA Galaxy @BBL P1P.json",
       "filename": "Panchroma PLA Galaxy @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3160,7 +3176,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/P1S/BambuStudio/Panchroma PLA Galaxy @BBL P1S.json",
       "filename": "Panchroma PLA Galaxy @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3191,7 +3207,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/P2S/BambuStudio/Panchroma PLA Galaxy @BBL P2S.json",
       "filename": "Panchroma PLA Galaxy @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3207,7 +3223,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/X1/BambuStudio/Panchroma PLA Galaxy @BBL X1.json",
       "filename": "Panchroma PLA Galaxy @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3269,12 +3285,28 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Galaxy/BBL/X2D/BambuStudio/Panchroma PLA Galaxy @BBL X2D.json",
       "filename": "Panchroma PLA Galaxy @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Panchroma PLA Galaxy",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/Panchroma PLA Galaxy/Creality/I7/CrealityPrint/Panchroma PLA Galaxy @Creality I7.json",
+      "filename": "Panchroma PLA Galaxy @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -3327,7 +3359,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/A1/BambuStudio/Panchroma PLA Glow @BBL A1.json",
       "filename": "Panchroma PLA Glow @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3369,7 +3401,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/A1M/BambuStudio/Panchroma PLA Glow @BBL A1M.json",
       "filename": "Panchroma PLA Glow @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3411,7 +3443,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/A2L/BambuStudio/Panchroma PLA Glow @BBL A2L.json",
       "filename": "Panchroma PLA Glow @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3427,7 +3459,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/H2C/BambuStudio/Panchroma PLA Glow @BBL H2C.json",
       "filename": "Panchroma PLA Glow @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3443,7 +3475,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/H2D/BambuStudio/Panchroma PLA Glow @BBL H2D.json",
       "filename": "Panchroma PLA Glow @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3459,7 +3491,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/H2S/BambuStudio/Panchroma PLA Glow @BBL H2S.json",
       "filename": "Panchroma PLA Glow @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3475,7 +3507,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/P1P/BambuStudio/Panchroma PLA Glow @BBL P1P.json",
       "filename": "Panchroma PLA Glow @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3507,7 +3539,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/P1S/BambuStudio/Panchroma PLA Glow @BBL P1S.json",
       "filename": "Panchroma PLA Glow @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3538,7 +3570,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/P2S/BambuStudio/Panchroma PLA Glow @BBL P2S.json",
       "filename": "Panchroma PLA Glow @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3554,7 +3586,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/X1/BambuStudio/Panchroma PLA Glow @BBL X1.json",
       "filename": "Panchroma PLA Glow @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3616,12 +3648,28 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Glow/BBL/X2D/BambuStudio/Panchroma PLA Glow @BBL X2D.json",
       "filename": "Panchroma PLA Glow @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Panchroma PLA Glow",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/Panchroma PLA Glow/Creality/I7/CrealityPrint/Panchroma PLA Glow @Creality I7.json",
+      "filename": "Panchroma PLA Glow @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -3674,7 +3722,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/A1/BambuStudio/Panchroma PLA Luminous @BBL A1.json",
       "filename": "Panchroma PLA Luminous @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3716,7 +3764,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/A1M/BambuStudio/Panchroma PLA Luminous @BBL A1M.json",
       "filename": "Panchroma PLA Luminous @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3758,7 +3806,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/A2L/BambuStudio/Panchroma PLA Luminous @BBL A2L.json",
       "filename": "Panchroma PLA Luminous @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3774,7 +3822,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/H2C/BambuStudio/Panchroma PLA Luminous @BBL H2C.json",
       "filename": "Panchroma PLA Luminous @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3790,7 +3838,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/H2D/BambuStudio/Panchroma PLA Luminous @BBL H2D.json",
       "filename": "Panchroma PLA Luminous @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3806,7 +3854,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/H2S/BambuStudio/Panchroma PLA Luminous @BBL H2S.json",
       "filename": "Panchroma PLA Luminous @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3822,7 +3870,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/P1P/BambuStudio/Panchroma PLA Luminous @BBL P1P.json",
       "filename": "Panchroma PLA Luminous @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3854,7 +3902,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/P1S/BambuStudio/Panchroma PLA Luminous @BBL P1S.json",
       "filename": "Panchroma PLA Luminous @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3885,7 +3933,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/P2S/BambuStudio/Panchroma PLA Luminous @BBL P2S.json",
       "filename": "Panchroma PLA Luminous @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3901,7 +3949,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/X1/BambuStudio/Panchroma PLA Luminous @BBL X1.json",
       "filename": "Panchroma PLA Luminous @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -3963,12 +4011,28 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Luminous/BBL/X2D/BambuStudio/Panchroma PLA Luminous @BBL X2D.json",
       "filename": "Panchroma PLA Luminous @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Panchroma PLA Luminous",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/Panchroma PLA Luminous/Creality/I7/CrealityPrint/Panchroma PLA Luminous @Creality I7.json",
+      "filename": "Panchroma PLA Luminous @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -4021,7 +4085,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/A1/BambuStudio/Panchroma PLA Marble @BBL A1.json",
       "filename": "Panchroma PLA Marble @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4063,7 +4127,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/A1M/BambuStudio/Panchroma PLA Marble @BBL A1M.json",
       "filename": "Panchroma PLA Marble @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4105,7 +4169,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/A2L/BambuStudio/Panchroma PLA Marble @BBL A2L.json",
       "filename": "Panchroma PLA Marble @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4121,7 +4185,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/H2C/BambuStudio/Panchroma PLA Marble @BBL H2C.json",
       "filename": "Panchroma PLA Marble @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4137,7 +4201,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/H2D/BambuStudio/Panchroma PLA Marble @BBL H2D.json",
       "filename": "Panchroma PLA Marble @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4153,7 +4217,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/P1P/BambuStudio/Panchroma PLA Marble @BBL P1P.json",
       "filename": "Panchroma PLA Marble @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4185,7 +4249,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/P2S/BambuStudio/Panchroma PLA Marble @BBL P2S.json",
       "filename": "Panchroma PLA Marble @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4201,7 +4265,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/X1/BambuStudio/Panchroma PLA Marble @BBL X1.json",
       "filename": "Panchroma PLA Marble @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4263,7 +4327,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Marble/BBL/X2D/BambuStudio/Panchroma PLA Marble @BBL X2D.json",
       "filename": "Panchroma PLA Marble @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4321,7 +4385,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/A1/BambuStudio/Panchroma PLA Matte @BBL A1.json",
       "filename": "Panchroma PLA Matte @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4363,7 +4427,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/A1M/BambuStudio/Panchroma PLA Matte @BBL A1M.json",
       "filename": "Panchroma PLA Matte @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4405,7 +4469,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/A2L/BambuStudio/Panchroma PLA Matte @BBL A2L.json",
       "filename": "Panchroma PLA Matte @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4421,7 +4485,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/H2C/BambuStudio/Panchroma PLA Matte @BBL H2C.json",
       "filename": "Panchroma PLA Matte @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4437,7 +4501,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/H2D/BambuStudio/Panchroma PLA Matte @BBL H2D.json",
       "filename": "Panchroma PLA Matte @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4453,7 +4517,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/P1P/BambuStudio/Panchroma PLA Matte @BBL P1P.json",
       "filename": "Panchroma PLA Matte @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4485,7 +4549,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/P2S/BambuStudio/Panchroma PLA Matte @BBL P2S.json",
       "filename": "Panchroma PLA Matte @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4501,7 +4565,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/X1/BambuStudio/Panchroma PLA Matte @BBL X1.json",
       "filename": "Panchroma PLA Matte @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4563,7 +4627,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Matte/BBL/X2D/BambuStudio/Panchroma PLA Matte @BBL X2D.json",
       "filename": "Panchroma PLA Matte @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4621,7 +4685,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/A1/BambuStudio/Panchroma PLA Metallic @BBL A1.json",
       "filename": "Panchroma PLA Metallic @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4663,7 +4727,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/A1M/BambuStudio/Panchroma PLA Metallic @BBL A1M.json",
       "filename": "Panchroma PLA Metallic @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4705,7 +4769,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/A2L/BambuStudio/Panchroma PLA Metallic @BBL A2L.json",
       "filename": "Panchroma PLA Metallic @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4721,7 +4785,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/H2C/BambuStudio/Panchroma PLA Metallic @BBL H2C.json",
       "filename": "Panchroma PLA Metallic @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4737,7 +4801,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/H2D/BambuStudio/Panchroma PLA Metallic @BBL H2D.json",
       "filename": "Panchroma PLA Metallic @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4753,7 +4817,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/H2S/BambuStudio/Panchroma PLA Metallic @BBL H2S.json",
       "filename": "Panchroma PLA Metallic @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4769,7 +4833,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/P1P/BambuStudio/Panchroma PLA Metallic @BBL P1P.json",
       "filename": "Panchroma PLA Metallic @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4801,7 +4865,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/P1S/BambuStudio/Panchroma PLA Metallic @BBL P1S.json",
       "filename": "Panchroma PLA Metallic @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4832,7 +4896,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/P2S/BambuStudio/Panchroma PLA Metallic @BBL P2S.json",
       "filename": "Panchroma PLA Metallic @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4848,7 +4912,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/X1/BambuStudio/Panchroma PLA Metallic @BBL X1.json",
       "filename": "Panchroma PLA Metallic @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -4910,12 +4974,28 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Metallic/BBL/X2D/BambuStudio/Panchroma PLA Metallic @BBL X2D.json",
       "filename": "Panchroma PLA Metallic @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Panchroma PLA Metallic",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/Panchroma PLA Metallic/Creality/I7/CrealityPrint/Panchroma PLA Metallic @Creality I7.json",
+      "filename": "Panchroma PLA Metallic @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -4968,7 +5048,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/A1/BambuStudio/Panchroma PLA Neon @BBL A1.json",
       "filename": "Panchroma PLA Neon @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5010,7 +5090,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/A1M/BambuStudio/Panchroma PLA Neon @BBL A1M.json",
       "filename": "Panchroma PLA Neon @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5052,7 +5132,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/A2L/BambuStudio/Panchroma PLA Neon @BBL A2L.json",
       "filename": "Panchroma PLA Neon @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5068,7 +5148,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/H2C/BambuStudio/Panchroma PLA Neon @BBL H2C.json",
       "filename": "Panchroma PLA Neon @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5084,7 +5164,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/H2D/BambuStudio/Panchroma PLA Neon @BBL H2D.json",
       "filename": "Panchroma PLA Neon @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5100,7 +5180,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/H2S/BambuStudio/Panchroma PLA Neon @BBL H2S.json",
       "filename": "Panchroma PLA Neon @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5116,7 +5196,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/P1P/BambuStudio/Panchroma PLA Neon @BBL P1P.json",
       "filename": "Panchroma PLA Neon @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5148,7 +5228,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/P1S/BambuStudio/Panchroma PLA Neon @BBL P1S.json",
       "filename": "Panchroma PLA Neon @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5179,7 +5259,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/P2S/BambuStudio/Panchroma PLA Neon @BBL P2S.json",
       "filename": "Panchroma PLA Neon @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5195,7 +5275,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/X1/BambuStudio/Panchroma PLA Neon @BBL X1.json",
       "filename": "Panchroma PLA Neon @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5257,12 +5337,28 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Neon/BBL/X2D/BambuStudio/Panchroma PLA Neon @BBL X2D.json",
       "filename": "Panchroma PLA Neon @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Panchroma PLA Neon",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/Panchroma PLA Neon/Creality/I7/CrealityPrint/Panchroma PLA Neon @Creality I7.json",
+      "filename": "Panchroma PLA Neon @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -5315,7 +5411,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Satin/BBL/A1/BambuStudio/Panchroma PLA Satin @BBL A1.json",
       "filename": "Panchroma PLA Satin @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5357,7 +5453,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Satin/BBL/A1M/BambuStudio/Panchroma PLA Satin @BBL A1M.json",
       "filename": "Panchroma PLA Satin @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5399,7 +5495,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Satin/BBL/H2C/BambuStudio/Panchroma PLA Satin @BBL H2C.json",
       "filename": "Panchroma PLA Satin @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5415,7 +5511,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Satin/BBL/H2S/BambuStudio/Panchroma PLA Satin @BBL H2S.json",
       "filename": "Panchroma PLA Satin @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5431,7 +5527,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Satin/BBL/P1P/BambuStudio/Panchroma PLA Satin @BBL P1P.json",
       "filename": "Panchroma PLA Satin @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5463,7 +5559,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Satin/BBL/P2S/BambuStudio/Panchroma PLA Satin @BBL P2S.json",
       "filename": "Panchroma PLA Satin @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5479,7 +5575,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Satin/BBL/X1/BambuStudio/Panchroma PLA Satin @BBL X1.json",
       "filename": "Panchroma PLA Satin @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5541,7 +5637,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Satin/BBL/X2D/BambuStudio/Panchroma PLA Satin @BBL X2D.json",
       "filename": "Panchroma PLA Satin @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5599,7 +5695,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/A1/BambuStudio/Panchroma PLA Silk @BBL A1.json",
       "filename": "Panchroma PLA Silk @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5641,7 +5737,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/A1M/BambuStudio/Panchroma PLA Silk @BBL A1M.json",
       "filename": "Panchroma PLA Silk @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5683,7 +5779,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/A2L/BambuStudio/Panchroma PLA Silk @BBL A2L.json",
       "filename": "Panchroma PLA Silk @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5699,7 +5795,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/H2C/BambuStudio/Panchroma PLA Silk @BBL H2C.json",
       "filename": "Panchroma PLA Silk @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5715,7 +5811,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/H2D/BambuStudio/Panchroma PLA Silk @BBL H2D.json",
       "filename": "Panchroma PLA Silk @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5731,7 +5827,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/H2S/BambuStudio/Panchroma PLA Silk @BBL H2S.json",
       "filename": "Panchroma PLA Silk @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5747,7 +5843,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/P1P/BambuStudio/Panchroma PLA Silk @BBL P1P.json",
       "filename": "Panchroma PLA Silk @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5779,7 +5875,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/P2S/BambuStudio/Panchroma PLA Silk @BBL P2S.json",
       "filename": "Panchroma PLA Silk @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5795,7 +5891,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/X1/BambuStudio/Panchroma PLA Silk @BBL X1.json",
       "filename": "Panchroma PLA Silk @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5857,7 +5953,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Silk/BBL/X2D/BambuStudio/Panchroma PLA Silk @BBL X2D.json",
       "filename": "Panchroma PLA Silk @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5915,7 +6011,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/A1/BambuStudio/Panchroma PLA Starlight @BBL A1.json",
       "filename": "Panchroma PLA Starlight @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5957,7 +6053,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/A1M/BambuStudio/Panchroma PLA Starlight @BBL A1M.json",
       "filename": "Panchroma PLA Starlight @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -5999,7 +6095,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/A2L/BambuStudio/Panchroma PLA Starlight @BBL A2L.json",
       "filename": "Panchroma PLA Starlight @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6015,7 +6111,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/H2C/BambuStudio/Panchroma PLA Starlight @BBL H2C.json",
       "filename": "Panchroma PLA Starlight @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6031,7 +6127,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/H2D/BambuStudio/Panchroma PLA Starlight @BBL H2D.json",
       "filename": "Panchroma PLA Starlight @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6047,7 +6143,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/H2S/BambuStudio/Panchroma PLA Starlight @BBL H2S.json",
       "filename": "Panchroma PLA Starlight @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6063,7 +6159,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/P1P/BambuStudio/Panchroma PLA Starlight @BBL P1P.json",
       "filename": "Panchroma PLA Starlight @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6095,7 +6191,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/P1S/BambuStudio/Panchroma PLA Starlight @BBL P1S.json",
       "filename": "Panchroma PLA Starlight @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6126,7 +6222,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/P2S/BambuStudio/Panchroma PLA Starlight @BBL P2S.json",
       "filename": "Panchroma PLA Starlight @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6142,7 +6238,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/X1/BambuStudio/Panchroma PLA Starlight @BBL X1.json",
       "filename": "Panchroma PLA Starlight @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6204,12 +6300,28 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Starlight/BBL/X2D/BambuStudio/Panchroma PLA Starlight @BBL X2D.json",
       "filename": "Panchroma PLA Starlight @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Panchroma PLA Starlight",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/Panchroma PLA Starlight/Creality/I7/CrealityPrint/Panchroma PLA Starlight @Creality I7.json",
+      "filename": "Panchroma PLA Starlight @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -6262,7 +6374,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Panchroma PLA Translucent/Anycubic/Kobra S1/OrcaSlicer/Panchroma PLA Translucent @Anycubic Kobra S1.json",
       "filename": "Panchroma PLA Translucent @Anycubic Kobra S1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "Anycubic",
@@ -6278,7 +6390,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/A1/BambuStudio/Panchroma PLA Translucent @BBL A1.json",
       "filename": "Panchroma PLA Translucent @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6320,7 +6432,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/A1M/BambuStudio/Panchroma PLA Translucent @BBL A1M.json",
       "filename": "Panchroma PLA Translucent @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6362,7 +6474,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/A2L/BambuStudio/Panchroma PLA Translucent @BBL A2L.json",
       "filename": "Panchroma PLA Translucent @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6378,7 +6490,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/H2C/BambuStudio/Panchroma PLA Translucent @BBL H2C.json",
       "filename": "Panchroma PLA Translucent @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6394,7 +6506,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/H2D/BambuStudio/Panchroma PLA Translucent @BBL H2D.json",
       "filename": "Panchroma PLA Translucent @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6410,7 +6522,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/H2S/BambuStudio/Panchroma PLA Translucent @BBL H2S.json",
       "filename": "Panchroma PLA Translucent @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6426,7 +6538,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/P1P/BambuStudio/Panchroma PLA Translucent @BBL P1P.json",
       "filename": "Panchroma PLA Translucent @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6458,7 +6570,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/P1S/BambuStudio/Panchroma PLA Translucent @BBL P1S.json",
       "filename": "Panchroma PLA Translucent @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6489,7 +6601,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/P2S/BambuStudio/Panchroma PLA Translucent @BBL P2S.json",
       "filename": "Panchroma PLA Translucent @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6505,7 +6617,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/X1/BambuStudio/Panchroma PLA Translucent @BBL X1.json",
       "filename": "Panchroma PLA Translucent @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6567,7 +6679,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA Translucent/BBL/X2D/BambuStudio/Panchroma PLA Translucent @BBL X2D.json",
       "filename": "Panchroma PLA Translucent @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6583,7 +6695,7 @@
       "slicer": "CrealityPrint",
       "path": "preset/Panchroma PLA Translucent/Creality/I7/CrealityPrint/Panchroma PLA Translucent @Creality I7.json",
       "filename": "Panchroma PLA Translucent @Creality I7.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "CreealityPrint",
@@ -6599,7 +6711,7 @@
       "slicer": "CrealityPrint",
       "path": "preset/Panchroma PLA Translucent/Creality/K2Pro/CrealityPrint/Panchroma PLA Translucent @Creality K2Pro.json",
       "filename": "Panchroma PLA Translucent @Creality K2Pro.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "CreealityPrint",
@@ -6641,7 +6753,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Panchroma PLA Translucent/QIDI/Q2/OrcaSlicer/Panchroma PLA Translucent @QIDI Q2.json",
       "filename": "Panchroma PLA Translucent @QIDI Q2.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "QIDI",
@@ -6673,7 +6785,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/A1/BambuStudio/Panchroma PLA UV Shift @BBL A1.json",
       "filename": "Panchroma PLA UV Shift @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6715,7 +6827,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/A1M/BambuStudio/Panchroma PLA UV Shift @BBL A1M.json",
       "filename": "Panchroma PLA UV Shift @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6757,7 +6869,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/A2L/BambuStudio/Panchroma PLA UV Shift @BBL A2L.json",
       "filename": "Panchroma PLA UV Shift @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6773,7 +6885,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/H2C/BambuStudio/Panchroma PLA UV Shift @BBL H2C.json",
       "filename": "Panchroma PLA UV Shift @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6789,7 +6901,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/H2D/BambuStudio/Panchroma PLA UV Shift @BBL H2D.json",
       "filename": "Panchroma PLA UV Shift @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6805,7 +6917,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/H2S/BambuStudio/Panchroma PLA UV Shift @BBL H2S.json",
       "filename": "Panchroma PLA UV Shift @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6821,7 +6933,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/P1P/BambuStudio/Panchroma PLA UV Shift @BBL P1P.json",
       "filename": "Panchroma PLA UV Shift @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6853,7 +6965,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/P1S/BambuStudio/Panchroma PLA UV Shift @BBL P1S.json",
       "filename": "Panchroma PLA UV Shift @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6884,7 +6996,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/P2S/BambuStudio/Panchroma PLA UV Shift @BBL P2S.json",
       "filename": "Panchroma PLA UV Shift @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6900,7 +7012,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/X1/BambuStudio/Panchroma PLA UV Shift @BBL X1.json",
       "filename": "Panchroma PLA UV Shift @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -6962,12 +7074,28 @@
       "slicer": "BambuStudio",
       "path": "preset/Panchroma PLA UV Shift/BBL/X2D/BambuStudio/Panchroma PLA UV Shift @BBL X2D.json",
       "filename": "Panchroma PLA UV Shift @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Panchroma PLA UV Shift",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/Panchroma PLA UV Shift/Creality/I7/CrealityPrint/Panchroma PLA UV Shift @Creality I7.json",
+      "filename": "Panchroma PLA UV Shift @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -7020,7 +7148,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyCast/BBL/A2L/BambuStudio/PolyCast @BBL A2L.json",
       "filename": "PolyCast @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7036,7 +7164,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyCast/BBL/H2S/BambuStudio/PolyCast @BBL H2S.json",
       "filename": "PolyCast @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7055,7 +7183,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyCast/BBL/P2S/BambuStudio/PolyCast @BBL P2S.json",
       "filename": "PolyCast @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7071,7 +7199,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyCast/BBL/X2D/BambuStudio/PolyCast @BBL X2D.json",
       "filename": "PolyCast @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7087,7 +7215,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95/BBL/A2L/BambuStudio/PolyFlex TPU95 @BBL A2L.json",
       "filename": "PolyFlex TPU95 @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7103,7 +7231,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95/BBL/H2S/BambuStudio/PolyFlex TPU95 @BBL H2S.json",
       "filename": "PolyFlex TPU95 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7119,7 +7247,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95/BBL/P1S/BambuStudio/PolyFlex TPU95 @BBL P1S.json",
       "filename": "PolyFlex TPU95 @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7150,7 +7278,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95/BBL/P2S/BambuStudio/PolyFlex TPU95 @BBL P2S.json",
       "filename": "PolyFlex TPU95 @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7169,7 +7297,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95/BBL/X2D/BambuStudio/PolyFlex TPU95 @BBL X2D.json",
       "filename": "PolyFlex TPU95 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7190,7 +7318,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyFlex TPU95/Elegoo/CC2/ElegooSlicer/PolyFlex TPU95 @Elegoo CC2.json",
       "filename": "PolyFlex TPU95 @Elegoo CC2.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -7206,7 +7334,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95-HF/BBL/A2L/BambuStudio/PolyFlex TPU95-HF @BBL A2L.json",
       "filename": "PolyFlex TPU95-HF @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7222,7 +7350,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95-HF/BBL/H2D/BambuStudio/PolyFlex TPU95-HF @BBL H2D.json",
       "filename": "PolyFlex TPU95-HF @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7242,7 +7370,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95-HF/BBL/H2S/BambuStudio/PolyFlex TPU95-HF @BBL H2S.json",
       "filename": "PolyFlex TPU95-HF @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7261,7 +7389,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyFlex TPU95-HF/BBL/X2D/BambuStudio/PolyFlex TPU95-HF @BBL X2D.json",
       "filename": "PolyFlex TPU95-HF @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7282,7 +7410,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite ABS/BBL/H2D/BambuStudio/PolyLite ABS @BBL H2D.json",
       "filename": "PolyLite ABS @BBL H2D.json",
-      "updatedAt": "2026-08-11T16:25:54+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7298,7 +7426,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite ABS/BBL/H2S/BambuStudio/PolyLite ABS @BBL H2S.json",
       "filename": "PolyLite ABS @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7317,7 +7445,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite ABS/BBL/P2S/BambuStudio/PolyLite ABS @BBL P2S.json",
       "filename": "PolyLite ABS @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7336,7 +7464,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite ABS/BBL/X2D/BambuStudio/PolyLite ABS @BBL X2D.json",
       "filename": "PolyLite ABS @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7357,7 +7485,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/A1/BambuStudio/PolyLite CosPLA @BBL A1.json",
       "filename": "PolyLite CosPLA @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7399,7 +7527,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/A1M/BambuStudio/PolyLite CosPLA @BBL A1M.json",
       "filename": "PolyLite CosPLA @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7441,7 +7569,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/A2L/BambuStudio/PolyLite CosPLA @BBL A2L.json",
       "filename": "PolyLite CosPLA @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7457,7 +7585,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/H2C/BambuStudio/PolyLite CosPLA @BBL H2C.json",
       "filename": "PolyLite CosPLA @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7473,7 +7601,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/H2D/BambuStudio/PolyLite CosPLA @BBL H2D.json",
       "filename": "PolyLite CosPLA @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7489,7 +7617,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/H2S/BambuStudio/PolyLite CosPLA @BBL H2S.json",
       "filename": "PolyLite CosPLA @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7505,7 +7633,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/P1P/BambuStudio/PolyLite CosPLA @BBL P1P.json",
       "filename": "PolyLite CosPLA @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7537,7 +7665,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/P2S/BambuStudio/PolyLite CosPLA @BBL P2S.json",
       "filename": "PolyLite CosPLA @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7553,7 +7681,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/X1/BambuStudio/PolyLite CosPLA @BBL X1.json",
       "filename": "PolyLite CosPLA @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7615,7 +7743,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite CosPLA/BBL/X2D/BambuStudio/PolyLite CosPLA @BBL X2D.json",
       "filename": "PolyLite CosPLA @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7673,7 +7801,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite LW-PLA/BBL/A2L/BambuStudio/PolyLite LW-PLA @BBL A2L.json",
       "filename": "PolyLite LW-PLA @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7689,7 +7817,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite LW-PLA/BBL/H2S/BambuStudio/PolyLite LW-PLA @BBL H2S.json",
       "filename": "PolyLite LW-PLA @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7708,7 +7836,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite LW-PLA/BBL/X2D/BambuStudio/PolyLite LW-PLA @BBL X2D.json",
       "filename": "PolyLite LW-PLA @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7729,7 +7857,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PC/BBL/H2D/BambuStudio/PolyLite PC @BBL H2D.json",
       "filename": "PolyLite PC @BBL H2D.json",
-      "updatedAt": "2026-08-11T16:25:54+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7748,7 +7876,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PC/BBL/H2S/BambuStudio/PolyLite PC @BBL H2S.json",
       "filename": "PolyLite PC @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7767,7 +7895,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PC/BBL/X2D/BambuStudio/PolyLite PC @BBL X2D.json",
       "filename": "PolyLite PC @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7820,7 +7948,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PETG/BBL/A2L/BambuStudio/PolyLite PETG @BBL A2L.json",
       "filename": "PolyLite PETG @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7836,7 +7964,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PETG/BBL/P2S/BambuStudio/PolyLite PETG @BBL P2S.json",
       "filename": "PolyLite PETG @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7855,7 +7983,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PETG/BBL/X2D/BambuStudio/PolyLite PETG @BBL X2D.json",
       "filename": "PolyLite PETG @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7908,7 +8036,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PETG Translucent/BBL/A2L/BambuStudio/PolyLite PETG Translucent @BBL A2L.json",
       "filename": "PolyLite PETG Translucent @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7924,7 +8052,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PETG Translucent/BBL/P2S/BambuStudio/PolyLite PETG Translucent @BBL P2S.json",
       "filename": "PolyLite PETG Translucent @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7943,7 +8071,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PETG Translucent/BBL/X2D/BambuStudio/PolyLite PETG Translucent @BBL X2D.json",
       "filename": "PolyLite PETG Translucent @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -7996,7 +8124,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/A1/BambuStudio/PolyLite PLA @BBL A1.json",
       "filename": "PolyLite PLA @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8038,7 +8166,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/A1M/BambuStudio/PolyLite PLA @BBL A1M.json",
       "filename": "PolyLite PLA @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8080,7 +8208,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/A2L/BambuStudio/PolyLite PLA @BBL A2L.json",
       "filename": "PolyLite PLA @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8096,7 +8224,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/H2C/BambuStudio/PolyLite PLA @BBL H2C.json",
       "filename": "PolyLite PLA @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8112,7 +8240,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/H2D/BambuStudio/PolyLite PLA @BBL H2D.json",
       "filename": "PolyLite PLA @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8128,7 +8256,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/H2S/BambuStudio/PolyLite PLA @BBL H2S.json",
       "filename": "PolyLite PLA @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8144,7 +8272,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/P1P/BambuStudio/PolyLite PLA @BBL P1P.json",
       "filename": "PolyLite PLA @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8176,7 +8304,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/P1S/BambuStudio/PolyLite PLA @BBL P1S.json",
       "filename": "PolyLite PLA @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8207,7 +8335,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/P2S/BambuStudio/PolyLite PLA @BBL P2S.json",
       "filename": "PolyLite PLA @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8223,7 +8351,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/X1/BambuStudio/PolyLite PLA @BBL X1.json",
       "filename": "PolyLite PLA @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8285,12 +8413,28 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA/BBL/X2D/BambuStudio/PolyLite PLA @BBL X2D.json",
       "filename": "PolyLite PLA @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "PolyLite PLA",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/PolyLite PLA/Creality/I7/CrealityPrint/PolyLite PLA @Creality I7.json",
+      "filename": "PolyLite PLA @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -8343,7 +8487,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/A1/BambuStudio/PolyLite PLA Galaxy @BBL A1.json",
       "filename": "PolyLite PLA Galaxy @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8385,7 +8529,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/A1M/BambuStudio/PolyLite PLA Galaxy @BBL A1M.json",
       "filename": "PolyLite PLA Galaxy @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8427,7 +8571,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/A2L/BambuStudio/PolyLite PLA Galaxy @BBL A2L.json",
       "filename": "PolyLite PLA Galaxy @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8443,7 +8587,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/H2C/BambuStudio/PolyLite PLA Galaxy @BBL H2C.json",
       "filename": "PolyLite PLA Galaxy @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8459,7 +8603,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/H2D/BambuStudio/PolyLite PLA Galaxy @BBL H2D.json",
       "filename": "PolyLite PLA Galaxy @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8475,7 +8619,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/H2S/BambuStudio/PolyLite PLA Galaxy @BBL H2S.json",
       "filename": "PolyLite PLA Galaxy @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8491,7 +8635,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/P1P/BambuStudio/PolyLite PLA Galaxy @BBL P1P.json",
       "filename": "PolyLite PLA Galaxy @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8523,7 +8667,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/P1S/BambuStudio/PolyLite PLA Galaxy @BBL P1S.json",
       "filename": "PolyLite PLA Galaxy @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8554,7 +8698,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/P2S/BambuStudio/PolyLite PLA Galaxy @BBL P2S.json",
       "filename": "PolyLite PLA Galaxy @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8570,7 +8714,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/X1/BambuStudio/PolyLite PLA Galaxy @BBL X1.json",
       "filename": "PolyLite PLA Galaxy @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8632,12 +8776,28 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Galaxy/BBL/X2D/BambuStudio/PolyLite PLA Galaxy @BBL X2D.json",
       "filename": "PolyLite PLA Galaxy @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "PolyLite PLA Galaxy",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/PolyLite PLA Galaxy/Creality/I7/CrealityPrint/PolyLite PLA Galaxy @Creality I7.json",
+      "filename": "PolyLite PLA Galaxy @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -8690,7 +8850,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/A1/BambuStudio/PolyLite PLA Glow @BBL A1.json",
       "filename": "PolyLite PLA Glow @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8732,7 +8892,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/A1M/BambuStudio/PolyLite PLA Glow @BBL A1M.json",
       "filename": "PolyLite PLA Glow @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8774,7 +8934,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/A2L/BambuStudio/PolyLite PLA Glow @BBL A2L.json",
       "filename": "PolyLite PLA Glow @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8790,7 +8950,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/H2C/BambuStudio/PolyLite PLA Glow @BBL H2C.json",
       "filename": "PolyLite PLA Glow @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8806,7 +8966,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/H2D/BambuStudio/PolyLite PLA Glow @BBL H2D.json",
       "filename": "PolyLite PLA Glow @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8822,7 +8982,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/H2S/BambuStudio/PolyLite PLA Glow @BBL H2S.json",
       "filename": "PolyLite PLA Glow @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8838,7 +8998,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/P1P/BambuStudio/PolyLite PLA Glow @BBL P1P.json",
       "filename": "PolyLite PLA Glow @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8870,7 +9030,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/P1S/BambuStudio/PolyLite PLA Glow @BBL P1S.json",
       "filename": "PolyLite PLA Glow @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8901,7 +9061,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/P2S/BambuStudio/PolyLite PLA Glow @BBL P2S.json",
       "filename": "PolyLite PLA Glow @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8917,7 +9077,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/X1/BambuStudio/PolyLite PLA Glow @BBL X1.json",
       "filename": "PolyLite PLA Glow @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -8979,12 +9139,28 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Glow/BBL/X2D/BambuStudio/PolyLite PLA Glow @BBL X2D.json",
       "filename": "PolyLite PLA Glow @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "PolyLite PLA Glow",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/PolyLite PLA Glow/Creality/I7/CrealityPrint/PolyLite PLA Glow @Creality I7.json",
+      "filename": "PolyLite PLA Glow @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -9037,7 +9213,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/A1/BambuStudio/PolyLite PLA Luminous @BBL A1.json",
       "filename": "PolyLite PLA Luminous @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9079,7 +9255,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/A1M/BambuStudio/PolyLite PLA Luminous @BBL A1M.json",
       "filename": "PolyLite PLA Luminous @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9121,7 +9297,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/A2L/BambuStudio/PolyLite PLA Luminous @BBL A2L.json",
       "filename": "PolyLite PLA Luminous @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9137,7 +9313,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/H2C/BambuStudio/PolyLite PLA Luminous @BBL H2C.json",
       "filename": "PolyLite PLA Luminous @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9156,7 +9332,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/H2D/BambuStudio/PolyLite PLA Luminous @BBL H2D.json",
       "filename": "PolyLite PLA Luminous @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9172,7 +9348,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/H2S/BambuStudio/PolyLite PLA Luminous @BBL H2S.json",
       "filename": "PolyLite PLA Luminous @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9188,7 +9364,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/P1P/BambuStudio/PolyLite PLA Luminous @BBL P1P.json",
       "filename": "PolyLite PLA Luminous @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9220,7 +9396,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/P1S/BambuStudio/PolyLite PLA Luminous @BBL P1S.json",
       "filename": "PolyLite PLA Luminous @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9251,7 +9427,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/P2S/BambuStudio/PolyLite PLA Luminous @BBL P2S.json",
       "filename": "PolyLite PLA Luminous @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9267,7 +9443,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/X1/BambuStudio/PolyLite PLA Luminous @BBL X1.json",
       "filename": "PolyLite PLA Luminous @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9329,7 +9505,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Luminous/BBL/X2D/BambuStudio/PolyLite PLA Luminous @BBL X2D.json",
       "filename": "PolyLite PLA Luminous @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9345,12 +9521,28 @@
     },
     {
       "material": "PolyLite PLA Luminous",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/PolyLite PLA Luminous/Creality/I7/CrealityPrint/PolyLite PLA Luminous @Creality I7.json",
+      "filename": "PolyLite PLA Luminous @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "PolyLite PLA Luminous",
       "brand": "Elegoo",
       "model": "CC2",
       "slicer": "ElegooSlicer",
       "path": "preset/PolyLite PLA Luminous/Elegoo/CC2/ElegooSlicer/PolyLite PLA Luminous @Elegoo CC2.json",
       "filename": "PolyLite PLA Luminous @Elegoo CC2.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -9366,7 +9558,7 @@
       "slicer": "PrusaSlicer",
       "path": "preset/PolyLite PLA Luminous/Prusa/Core One/PrusaSlicer/PolyLite PLA Luminous @Prusa Core One.ini",
       "filename": "PolyLite PLA Luminous @Prusa Core One.ini",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": []
     },
     {
@@ -9392,7 +9584,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/A1/BambuStudio/PolyLite PLA Neon @BBL A1.json",
       "filename": "PolyLite PLA Neon @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9434,7 +9626,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/A1M/BambuStudio/PolyLite PLA Neon @BBL A1M.json",
       "filename": "PolyLite PLA Neon @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9476,7 +9668,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/A2L/BambuStudio/PolyLite PLA Neon @BBL A2L.json",
       "filename": "PolyLite PLA Neon @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9492,7 +9684,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/H2C/BambuStudio/PolyLite PLA Neon @BBL H2C.json",
       "filename": "PolyLite PLA Neon @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9508,7 +9700,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/H2D/BambuStudio/PolyLite PLA Neon @BBL H2D.json",
       "filename": "PolyLite PLA Neon @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9524,7 +9716,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/H2S/BambuStudio/PolyLite PLA Neon @BBL H2S.json",
       "filename": "PolyLite PLA Neon @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9540,7 +9732,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/P1P/BambuStudio/PolyLite PLA Neon @BBL P1P.json",
       "filename": "PolyLite PLA Neon @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9572,7 +9764,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/P1S/BambuStudio/PolyLite PLA Neon @BBL P1S.json",
       "filename": "PolyLite PLA Neon @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9603,7 +9795,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/P2S/BambuStudio/PolyLite PLA Neon @BBL P2S.json",
       "filename": "PolyLite PLA Neon @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9619,7 +9811,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/X1/BambuStudio/PolyLite PLA Neon @BBL X1.json",
       "filename": "PolyLite PLA Neon @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9681,12 +9873,28 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Neon/BBL/X2D/BambuStudio/PolyLite PLA Neon @BBL X2D.json",
       "filename": "PolyLite PLA Neon @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "PolyLite PLA Neon",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/PolyLite PLA Neon/Creality/I7/CrealityPrint/PolyLite PLA Neon @Creality I7.json",
+      "filename": "PolyLite PLA Neon @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -9739,7 +9947,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro/BBL/A2L/BambuStudio/PolyLite PLA Pro @BBL A2L.json",
       "filename": "PolyLite PLA Pro @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9755,7 +9963,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro/BBL/H2C/BambuStudio/PolyLite PLA Pro @BBL H2C.json",
       "filename": "PolyLite PLA Pro @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9771,7 +9979,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro/BBL/H2D/BambuStudio/PolyLite PLA Pro @BBL H2D.json",
       "filename": "PolyLite PLA Pro @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9787,7 +9995,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro/BBL/H2S/BambuStudio/PolyLite PLA Pro @BBL H2S.json",
       "filename": "PolyLite PLA Pro @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9803,7 +10011,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro/BBL/P2S/BambuStudio/PolyLite PLA Pro @BBL P2S.json",
       "filename": "PolyLite PLA Pro @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9819,7 +10027,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro/BBL/X2D/BambuStudio/PolyLite PLA Pro @BBL X2D.json",
       "filename": "PolyLite PLA Pro @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9877,7 +10085,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro Metallic/BBL/A2L/BambuStudio/PolyLite PLA Pro Metallic @BBL A2L.json",
       "filename": "PolyLite PLA Pro Metallic @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9893,7 +10101,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro Metallic/BBL/H2C/BambuStudio/PolyLite PLA Pro Metallic @BBL H2C.json",
       "filename": "PolyLite PLA Pro Metallic @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9909,7 +10117,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro Metallic/BBL/H2D/BambuStudio/PolyLite PLA Pro Metallic @BBL H2D.json",
       "filename": "PolyLite PLA Pro Metallic @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9925,7 +10133,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro Metallic/BBL/H2S/BambuStudio/PolyLite PLA Pro Metallic @BBL H2S.json",
       "filename": "PolyLite PLA Pro Metallic @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9941,7 +10149,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro Metallic/BBL/P2S/BambuStudio/PolyLite PLA Pro Metallic @BBL P2S.json",
       "filename": "PolyLite PLA Pro Metallic @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -9957,7 +10165,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Pro Metallic/BBL/X2D/BambuStudio/PolyLite PLA Pro Metallic @BBL X2D.json",
       "filename": "PolyLite PLA Pro Metallic @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10015,7 +10223,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/A1/BambuStudio/PolyLite PLA Starlight @BBL A1.json",
       "filename": "PolyLite PLA Starlight @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10057,7 +10265,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/A1M/BambuStudio/PolyLite PLA Starlight @BBL A1M.json",
       "filename": "PolyLite PLA Starlight @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10099,7 +10307,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/A2L/BambuStudio/PolyLite PLA Starlight @BBL A2L.json",
       "filename": "PolyLite PLA Starlight @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10115,7 +10323,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/H2C/BambuStudio/PolyLite PLA Starlight @BBL H2C.json",
       "filename": "PolyLite PLA Starlight @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10131,7 +10339,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/H2D/BambuStudio/PolyLite PLA Starlight @BBL H2D.json",
       "filename": "PolyLite PLA Starlight @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10147,7 +10355,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/H2S/BambuStudio/PolyLite PLA Starlight @BBL H2S.json",
       "filename": "PolyLite PLA Starlight @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10163,7 +10371,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/P1P/BambuStudio/PolyLite PLA Starlight @BBL P1P.json",
       "filename": "PolyLite PLA Starlight @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10195,7 +10403,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/P1S/BambuStudio/PolyLite PLA Starlight @BBL P1S.json",
       "filename": "PolyLite PLA Starlight @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10226,7 +10434,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/P2S/BambuStudio/PolyLite PLA Starlight @BBL P2S.json",
       "filename": "PolyLite PLA Starlight @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10242,7 +10450,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/X1/BambuStudio/PolyLite PLA Starlight @BBL X1.json",
       "filename": "PolyLite PLA Starlight @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10304,12 +10512,28 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Starlight/BBL/X2D/BambuStudio/PolyLite PLA Starlight @BBL X2D.json",
       "filename": "PolyLite PLA Starlight @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "PolyLite PLA Starlight",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/PolyLite PLA Starlight/Creality/I7/CrealityPrint/PolyLite PLA Starlight @Creality I7.json",
+      "filename": "PolyLite PLA Starlight @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -10362,7 +10586,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/A1/BambuStudio/PolyLite PLA Translucent @BBL A1.json",
       "filename": "PolyLite PLA Translucent @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10404,7 +10628,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/A1M/BambuStudio/PolyLite PLA Translucent @BBL A1M.json",
       "filename": "PolyLite PLA Translucent @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10446,7 +10670,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/A2L/BambuStudio/PolyLite PLA Translucent @BBL A2L.json",
       "filename": "PolyLite PLA Translucent @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10462,7 +10686,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/H2C/BambuStudio/PolyLite PLA Translucent @BBL H2C.json",
       "filename": "PolyLite PLA Translucent @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10478,7 +10702,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/H2D/BambuStudio/PolyLite PLA Translucent @BBL H2D.json",
       "filename": "PolyLite PLA Translucent @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10494,7 +10718,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/H2S/BambuStudio/PolyLite PLA Translucent @BBL H2S.json",
       "filename": "PolyLite PLA Translucent @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10510,7 +10734,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/P1P/BambuStudio/PolyLite PLA Translucent @BBL P1P.json",
       "filename": "PolyLite PLA Translucent @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10542,7 +10766,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/P1S/BambuStudio/PolyLite PLA Translucent @BBL P1S.json",
       "filename": "PolyLite PLA Translucent @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10573,7 +10797,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/P2S/BambuStudio/PolyLite PLA Translucent @BBL P2S.json",
       "filename": "PolyLite PLA Translucent @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10589,7 +10813,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/X1/BambuStudio/PolyLite PLA Translucent @BBL X1.json",
       "filename": "PolyLite PLA Translucent @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10651,12 +10875,28 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA Translucent/BBL/X2D/BambuStudio/PolyLite PLA Translucent @BBL X2D.json",
       "filename": "PolyLite PLA Translucent @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
           "model": "X2D",
           "fullName": "Bambu Lab X2D 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "PolyLite PLA Translucent",
+      "brand": "Creality",
+      "model": "I7",
+      "slicer": "CrealityPrint",
+      "path": "preset/PolyLite PLA Translucent/Creality/I7/CrealityPrint/PolyLite PLA Translucent @Creality I7.json",
+      "filename": "PolyLite PLA Translucent @Creality I7.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "CreealityPrint",
+          "model": "I7",
+          "fullName": "SPARKX i7 0.4 nozzle"
         }
       ]
     },
@@ -10709,7 +10949,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA-CF/BBL/A2L/BambuStudio/PolyLite PLA-CF @BBL A2L.json",
       "filename": "PolyLite PLA-CF @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10725,7 +10965,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA-CF/BBL/H2S/BambuStudio/PolyLite PLA-CF @BBL H2S.json",
       "filename": "PolyLite PLA-CF @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10744,7 +10984,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyLite PLA-CF/BBL/X2D/BambuStudio/PolyLite PLA-CF @BBL X2D.json",
       "filename": "PolyLite PLA-CF @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10781,7 +11021,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PC/BBL/H2D/BambuStudio/PolyMax PC @BBL H2D.json",
       "filename": "PolyMax PC @BBL H2D.json",
-      "updatedAt": "2026-08-11T16:25:54+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10800,7 +11040,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PC/BBL/H2S/BambuStudio/PolyMax PC @BBL H2S.json",
       "filename": "PolyMax PC @BBL H2S.json",
-      "updatedAt": "2026-08-11T16:25:54+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10819,7 +11059,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PC/BBL/X2D/BambuStudio/PolyMax PC @BBL X2D.json",
       "filename": "PolyMax PC @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10856,7 +11096,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PETG/BBL/A2L/BambuStudio/PolyMax PETG @BBL A2L.json",
       "filename": "PolyMax PETG @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10872,7 +11112,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PETG/BBL/H2D/BambuStudio/PolyMax PETG @BBL H2D.json",
       "filename": "PolyMax PETG @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10891,7 +11131,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PETG/BBL/H2S/BambuStudio/PolyMax PETG @BBL H2S.json",
       "filename": "PolyMax PETG @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10910,7 +11150,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PETG/BBL/P2S/BambuStudio/PolyMax PETG @BBL P2S.json",
       "filename": "PolyMax PETG @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10929,7 +11169,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PETG/BBL/X2D/BambuStudio/PolyMax PETG @BBL X2D.json",
       "filename": "PolyMax PETG @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10950,7 +11190,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/PolyMax PETG/Elegoo/CC2/ElegooSlicer/PolyMax PETG @Elegoo CC2.json",
       "filename": "PolyMax PETG @Elegoo CC2.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -10966,7 +11206,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PLA/BBL/A2L/BambuStudio/PolyMax PLA @BBL A2L.json",
       "filename": "PolyMax PLA @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10982,7 +11222,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PLA/BBL/H2C/BambuStudio/PolyMax PLA @BBL H2C.json",
       "filename": "PolyMax PLA @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -10998,7 +11238,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PLA/BBL/H2D/BambuStudio/PolyMax PLA @BBL H2D.json",
       "filename": "PolyMax PLA @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11014,7 +11254,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PLA/BBL/H2S/BambuStudio/PolyMax PLA @BBL H2S.json",
       "filename": "PolyMax PLA @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11030,7 +11270,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PLA/BBL/P2S/BambuStudio/PolyMax PLA @BBL P2S.json",
       "filename": "PolyMax PLA @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11046,7 +11286,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyMax PLA/BBL/X2D/BambuStudio/PolyMax PLA @BBL X2D.json",
       "filename": "PolyMax PLA @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11093,7 +11333,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolySmooth/BBL/A2L/BambuStudio/PolySmooth @BBL A2L.json",
       "filename": "PolySmooth @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11109,7 +11349,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolySmooth/BBL/H2S/BambuStudio/PolySmooth @BBL H2S.json",
       "filename": "PolySmooth @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11125,7 +11365,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolySmooth/BBL/X2D/BambuStudio/PolySmooth @BBL X2D.json",
       "filename": "PolySmooth @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11141,7 +11381,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolySupport/BBL/A2L/BambuStudio/PolySupport @BBL A2L.json",
       "filename": "PolySupport @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11157,7 +11397,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolySupport/BBL/H2S/BambuStudio/PolySupport @BBL H2S.json",
       "filename": "PolySupport @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11176,7 +11416,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolySupport/BBL/X2D/BambuStudio/PolySupport @BBL X2D.json",
       "filename": "PolySupport @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11196,7 +11436,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolySupport for PA12/BBL/H2S/BambuStudio/PolySupport for PA12 @BBL H2S.json",
       "filename": "PolySupport for PA12 @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11215,7 +11455,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolySupport for PA12/BBL/P2S/BambuStudio/PolySupport for PA12 @BBL P2S.json",
       "filename": "PolySupport for PA12 @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11234,7 +11474,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolySupport for PA12/BBL/X2D/BambuStudio/PolySupport for PA12 @BBL X2D.json",
       "filename": "PolySupport for PA12 @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11254,7 +11494,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/A1/BambuStudio/PolyTerra PLA @BBL A1.json",
       "filename": "PolyTerra PLA @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11296,7 +11536,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/A1M/BambuStudio/PolyTerra PLA @BBL A1M.json",
       "filename": "PolyTerra PLA @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11338,7 +11578,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/A2L/BambuStudio/PolyTerra PLA @BBL A2L.json",
       "filename": "PolyTerra PLA @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11354,7 +11594,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/H2C/BambuStudio/PolyTerra PLA @BBL H2C.json",
       "filename": "PolyTerra PLA @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11370,7 +11610,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/H2D/BambuStudio/PolyTerra PLA @BBL H2D.json",
       "filename": "PolyTerra PLA @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11386,7 +11626,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/P1P/BambuStudio/PolyTerra PLA @BBL P1P.json",
       "filename": "PolyTerra PLA @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11418,7 +11658,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/P2S/BambuStudio/PolyTerra PLA @BBL P2S.json",
       "filename": "PolyTerra PLA @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11434,7 +11674,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/X1/BambuStudio/PolyTerra PLA @BBL X1.json",
       "filename": "PolyTerra PLA @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11496,7 +11736,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA/BBL/X2D/BambuStudio/PolyTerra PLA @BBL X2D.json",
       "filename": "PolyTerra PLA @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11554,7 +11794,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/A1/BambuStudio/PolyTerra PLA Marble @BBL A1.json",
       "filename": "PolyTerra PLA Marble @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11596,7 +11836,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/A1M/BambuStudio/PolyTerra PLA Marble @BBL A1M.json",
       "filename": "PolyTerra PLA Marble @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11638,7 +11878,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/A2L/BambuStudio/PolyTerra PLA Marble @BBL A2L.json",
       "filename": "PolyTerra PLA Marble @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11654,7 +11894,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/H2C/BambuStudio/PolyTerra PLA Marble @BBL H2C.json",
       "filename": "PolyTerra PLA Marble @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11670,7 +11910,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/H2D/BambuStudio/PolyTerra PLA Marble @BBL H2D.json",
       "filename": "PolyTerra PLA Marble @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11686,7 +11926,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/P1P/BambuStudio/PolyTerra PLA Marble @BBL P1P.json",
       "filename": "PolyTerra PLA Marble @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11718,7 +11958,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/P2S/BambuStudio/PolyTerra PLA Marble @BBL P2S.json",
       "filename": "PolyTerra PLA Marble @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11734,7 +11974,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/X1/BambuStudio/PolyTerra PLA Marble @BBL X1.json",
       "filename": "PolyTerra PLA Marble @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11796,7 +12036,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA Marble/BBL/X2D/BambuStudio/PolyTerra PLA Marble @BBL X2D.json",
       "filename": "PolyTerra PLA Marble @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11854,7 +12094,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA+/BBL/A1/BambuStudio/PolyTerra PLA+ @BBL A1.json",
       "filename": "PolyTerra PLA+ @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11896,7 +12136,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA+/BBL/A1M/BambuStudio/PolyTerra PLA+ @BBL A1M.json",
       "filename": "PolyTerra PLA+ @BBL A1M.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11938,7 +12178,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA+/BBL/H2C/BambuStudio/PolyTerra PLA+ @BBL H2C.json",
       "filename": "PolyTerra PLA+ @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11954,7 +12194,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA+/BBL/H2S/BambuStudio/PolyTerra PLA+ @BBL H2S.json",
       "filename": "PolyTerra PLA+ @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -11970,7 +12210,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA+/BBL/P1P/BambuStudio/PolyTerra PLA+ @BBL P1P.json",
       "filename": "PolyTerra PLA+ @BBL P1P.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12002,7 +12242,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA+/BBL/P2S/BambuStudio/PolyTerra PLA+ @BBL P2S.json",
       "filename": "PolyTerra PLA+ @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12018,7 +12258,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA+/BBL/X1/BambuStudio/PolyTerra PLA+ @BBL X1.json",
       "filename": "PolyTerra PLA+ @BBL X1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12080,7 +12320,7 @@
       "slicer": "BambuStudio",
       "path": "preset/PolyTerra PLA+/BBL/X2D/BambuStudio/PolyTerra PLA+ @BBL X2D.json",
       "filename": "PolyTerra PLA+ @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12134,11 +12374,27 @@
     {
       "material": "Polylite ASA for TYC Americas",
       "brand": "BBL",
+      "model": "H2C",
+      "slicer": "BambuStudio",
+      "path": "preset/Polylite ASA for TYC Americas/BBL/H2C/BambuStudio/Polylite ASA for TYC Americas @BBL H2C.json",
+      "filename": "Polylite ASA for TYC Americas @BBL H2C.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "BBL",
+          "model": "H2C",
+          "fullName": "Bambu Lab H2C 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Polylite ASA for TYC Americas",
+      "brand": "BBL",
       "model": "H2D",
       "slicer": "BambuStudio",
       "path": "preset/Polylite ASA for TYC Americas/BBL/H2D/BambuStudio/Polylite ASA for TYC Americas @BBL H2D.json",
       "filename": "Polylite ASA for TYC Americas @BBL H2D.json",
-      "updatedAt": "2026-08-11T16:25:54+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12157,7 +12413,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polylite ASA for TYC Americas/BBL/H2S/BambuStudio/Polylite ASA for TYC Americas @BBL H2S.json",
       "filename": "Polylite ASA for TYC Americas @BBL H2S.json",
-      "updatedAt": "2026-08-11T16:25:54+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12176,7 +12432,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polylite ASA for TYC Americas/BBL/P2S/BambuStudio/Polylite ASA for TYC Americas @BBL P2S.json",
       "filename": "Polylite ASA for TYC Americas @BBL P2S.json",
-      "updatedAt": "2026-08-11T16:25:54+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12195,7 +12451,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polylite ASA for TYC Americas/BBL/X2D/BambuStudio/Polylite ASA for TYC Americas @BBL X2D.json",
       "filename": "Polylite ASA for TYC Americas @BBL X2D.json",
-      "updatedAt": "2026-08-11T16:25:54+08:00",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12227,7 +12483,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Max/BBL/H2C/BambuStudio/Polymaker ABS Max @BBL H2C.json",
       "filename": "Polymaker ABS Max @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12246,7 +12502,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Max/BBL/H2D/BambuStudio/Polymaker ABS Max @BBL H2D.json",
       "filename": "Polymaker ABS Max @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12265,7 +12521,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Max/BBL/H2S/BambuStudio/Polymaker ABS Max @BBL H2S.json",
       "filename": "Polymaker ABS Max @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12284,7 +12540,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Max/BBL/P1S/BambuStudio/Polymaker ABS Max @BBL P1S.json",
       "filename": "Polymaker ABS Max @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12315,7 +12571,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Max/BBL/P2S/BambuStudio/Polymaker ABS Max @BBL P2S.json",
       "filename": "Polymaker ABS Max @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12334,7 +12590,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Max/BBL/X2D/BambuStudio/Polymaker ABS Max @BBL X2D.json",
       "filename": "Polymaker ABS Max @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12419,7 +12675,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro/BBL/H2C/BambuStudio/Polymaker ABS Pro @BBL H2C.json",
       "filename": "Polymaker ABS Pro @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12435,7 +12691,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro/BBL/H2D/BambuStudio/Polymaker ABS Pro @BBL H2D.json",
       "filename": "Polymaker ABS Pro @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12454,7 +12710,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro/BBL/H2S/BambuStudio/Polymaker ABS Pro @BBL H2S.json",
       "filename": "Polymaker ABS Pro @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12473,7 +12729,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro/BBL/P1S/BambuStudio/Polymaker ABS Pro @BBL P1S.json",
       "filename": "Polymaker ABS Pro @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12504,7 +12760,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro/BBL/P2S/BambuStudio/Polymaker ABS Pro @BBL P2S.json",
       "filename": "Polymaker ABS Pro @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12523,7 +12779,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro/BBL/X2D/BambuStudio/Polymaker ABS Pro @BBL X2D.json",
       "filename": "Polymaker ABS Pro @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12608,7 +12864,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro Galaxy/BBL/H2C/BambuStudio/Polymaker ABS Pro Galaxy @BBL H2C.json",
       "filename": "Polymaker ABS Pro Galaxy @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12624,7 +12880,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro Galaxy/BBL/H2D/BambuStudio/Polymaker ABS Pro Galaxy @BBL H2D.json",
       "filename": "Polymaker ABS Pro Galaxy @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12643,7 +12899,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro Galaxy/BBL/H2S/BambuStudio/Polymaker ABS Pro Galaxy @BBL H2S.json",
       "filename": "Polymaker ABS Pro Galaxy @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12662,7 +12918,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro Galaxy/BBL/P1S/BambuStudio/Polymaker ABS Pro Galaxy @BBL P1S.json",
       "filename": "Polymaker ABS Pro Galaxy @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12693,7 +12949,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro Galaxy/BBL/P2S/BambuStudio/Polymaker ABS Pro Galaxy @BBL P2S.json",
       "filename": "Polymaker ABS Pro Galaxy @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12712,7 +12968,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ABS Pro Galaxy/BBL/X2D/BambuStudio/Polymaker ABS Pro Galaxy @BBL X2D.json",
       "filename": "Polymaker ABS Pro Galaxy @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12777,11 +13033,27 @@
     {
       "material": "Polymaker ASA",
       "brand": "BBL",
+      "model": "H2C",
+      "slicer": "BambuStudio",
+      "path": "preset/Polymaker ASA/BBL/H2C/BambuStudio/Polymaker ASA @BBL H2C.json",
+      "filename": "Polymaker ASA @BBL H2C.json",
+      "updatedAt": "2026-08-25T09:37:13+08:00",
+      "compatiblePrinters": [
+        {
+          "brand": "BBL",
+          "model": "H2C",
+          "fullName": "Bambu Lab H2C 0.4 nozzle"
+        }
+      ]
+    },
+    {
+      "material": "Polymaker ASA",
+      "brand": "BBL",
       "model": "H2D",
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ASA/BBL/H2D/BambuStudio/Polymaker ASA @BBL H2D.json",
       "filename": "Polymaker ASA @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12800,7 +13072,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ASA/BBL/H2S/BambuStudio/Polymaker ASA @BBL H2S.json",
       "filename": "Polymaker ASA @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12819,7 +13091,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ASA/BBL/P2S/BambuStudio/Polymaker ASA @BBL P2S.json",
       "filename": "Polymaker ASA @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12838,7 +13110,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker ASA/BBL/X2D/BambuStudio/Polymaker ASA @BBL X2D.json",
       "filename": "Polymaker ASA @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12870,7 +13142,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA/BBL/A2L/BambuStudio/Polymaker HT-PLA @BBL A2L.json",
       "filename": "Polymaker HT-PLA @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12886,7 +13158,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA/BBL/H2C/BambuStudio/Polymaker HT-PLA @BBL H2C.json",
       "filename": "Polymaker HT-PLA @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12902,7 +13174,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA/BBL/H2D/BambuStudio/Polymaker HT-PLA @BBL H2D.json",
       "filename": "Polymaker HT-PLA @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12918,7 +13190,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA/BBL/H2S/BambuStudio/Polymaker HT-PLA @BBL H2S.json",
       "filename": "Polymaker HT-PLA @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12934,7 +13206,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA/BBL/P1S/BambuStudio/Polymaker HT-PLA @BBL P1S.json",
       "filename": "Polymaker HT-PLA @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12965,7 +13237,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA/BBL/P2S/BambuStudio/Polymaker HT-PLA @BBL P2S.json",
       "filename": "Polymaker HT-PLA @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -12981,7 +13253,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA/BBL/X2D/BambuStudio/Polymaker HT-PLA @BBL X2D.json",
       "filename": "Polymaker HT-PLA @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13044,7 +13316,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker HT-PLA Pro/Anycubic/Kobra S1/OrcaSlicer/Polymaker HT-PLA Pro @Anycubic Kobra S1.json",
       "filename": "Polymaker HT-PLA Pro @Anycubic Kobra S1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "Anycubic",
@@ -13060,7 +13332,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA Pro/BBL/A1/BambuStudio/Polymaker HT-PLA Pro @BBL A1.json",
       "filename": "Polymaker HT-PLA Pro @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13081,7 +13353,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA Pro/BBL/A2L/BambuStudio/Polymaker HT-PLA Pro @BBL A2L.json",
       "filename": "Polymaker HT-PLA Pro @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13097,7 +13369,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA Pro/BBL/H2C/BambuStudio/Polymaker HT-PLA Pro @BBL H2C.json",
       "filename": "Polymaker HT-PLA Pro @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13113,7 +13385,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA Pro/BBL/H2D/BambuStudio/Polymaker HT-PLA Pro @BBL H2D.json",
       "filename": "Polymaker HT-PLA Pro @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13129,7 +13401,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA Pro/BBL/H2S/BambuStudio/Polymaker HT-PLA Pro @BBL H2S.json",
       "filename": "Polymaker HT-PLA Pro @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13145,7 +13417,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA Pro/BBL/P1S/BambuStudio/Polymaker HT-PLA Pro @BBL P1S.json",
       "filename": "Polymaker HT-PLA Pro @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13176,7 +13448,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA Pro/BBL/P2S/BambuStudio/Polymaker HT-PLA Pro @BBL P2S.json",
       "filename": "Polymaker HT-PLA Pro @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13192,7 +13464,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA Pro/BBL/X2D/BambuStudio/Polymaker HT-PLA Pro @BBL X2D.json",
       "filename": "Polymaker HT-PLA Pro @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13208,7 +13480,7 @@
       "slicer": "CrealityPrint",
       "path": "preset/Polymaker HT-PLA Pro/Creality/I7/CrealityPrint/Polymaker HT-PLA Pro @Creality I7.json",
       "filename": "Polymaker HT-PLA Pro @Creality I7.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "CreealityPrint",
@@ -13224,7 +13496,7 @@
       "slicer": "CrealityPrint",
       "path": "preset/Polymaker HT-PLA Pro/Creality/K2Pro/CrealityPrint/Polymaker HT-PLA Pro @Creality K2Pro.json",
       "filename": "Polymaker HT-PLA Pro @Creality K2Pro.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "CreealityPrint",
@@ -13240,7 +13512,7 @@
       "slicer": "ElegooSlicer",
       "path": "preset/Polymaker HT-PLA Pro/Elegoo/CC2/ElegooSlicer/Polymaker HT-PLA Pro @Elegoo CC2.json",
       "filename": "Polymaker HT-PLA Pro @Elegoo CC2.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "Elegoo",
@@ -13256,7 +13528,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker HT-PLA Pro/QIDI/Q2/OrcaSlicer/Polymaker HT-PLA Pro @QIDI Q2.json",
       "filename": "Polymaker HT-PLA Pro @QIDI Q2.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "QIDI",
@@ -13272,7 +13544,7 @@
       "slicer": "OrcaSlicer",
       "path": "preset/Polymaker HT-PLA Pro/Snapmaker/U1/OrcaSlicer/Polymaker HT-PLA Pro @Snapmaker U1.json",
       "filename": "Polymaker HT-PLA Pro @Snapmaker U1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "Snapmaker",
@@ -13288,7 +13560,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA-GF/BBL/A2L/BambuStudio/Polymaker HT-PLA-GF @BBL A2L.json",
       "filename": "Polymaker HT-PLA-GF @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13304,7 +13576,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA-GF/BBL/H2C/BambuStudio/Polymaker HT-PLA-GF @BBL H2C.json",
       "filename": "Polymaker HT-PLA-GF @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13320,7 +13592,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA-GF/BBL/H2D/BambuStudio/Polymaker HT-PLA-GF @BBL H2D.json",
       "filename": "Polymaker HT-PLA-GF @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13336,7 +13608,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA-GF/BBL/H2S/BambuStudio/Polymaker HT-PLA-GF @BBL H2S.json",
       "filename": "Polymaker HT-PLA-GF @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13352,7 +13624,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA-GF/BBL/P2S/BambuStudio/Polymaker HT-PLA-GF @BBL P2S.json",
       "filename": "Polymaker HT-PLA-GF @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13368,7 +13640,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker HT-PLA-GF/BBL/X2D/BambuStudio/Polymaker HT-PLA-GF @BBL X2D.json",
       "filename": "Polymaker HT-PLA-GF @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13426,7 +13698,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG/BBL/A1/BambuStudio/Polymaker PETG @BBL A1.json",
       "filename": "Polymaker PETG @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13447,7 +13719,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG/BBL/A2L/BambuStudio/Polymaker PETG @BBL A2L.json",
       "filename": "Polymaker PETG @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13463,7 +13735,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG/BBL/H2C/BambuStudio/Polymaker PETG @BBL H2C.json",
       "filename": "Polymaker PETG @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13482,7 +13754,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG/BBL/H2D/BambuStudio/Polymaker PETG @BBL H2D.json",
       "filename": "Polymaker PETG @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13501,7 +13773,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG/BBL/H2S/BambuStudio/Polymaker PETG @BBL H2S.json",
       "filename": "Polymaker PETG @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13520,7 +13792,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG/BBL/P1S/BambuStudio/Polymaker PETG @BBL P1S.json",
       "filename": "Polymaker PETG @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13551,7 +13823,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG/BBL/P2S/BambuStudio/Polymaker PETG @BBL P2S.json",
       "filename": "Polymaker PETG @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13570,7 +13842,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG/BBL/X2D/BambuStudio/Polymaker PETG @BBL X2D.json",
       "filename": "Polymaker PETG @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13633,7 +13905,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG Galaxy/BBL/A1/BambuStudio/Polymaker PETG Galaxy @BBL A1.json",
       "filename": "Polymaker PETG Galaxy @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13654,7 +13926,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG Galaxy/BBL/A2L/BambuStudio/Polymaker PETG Galaxy @BBL A2L.json",
       "filename": "Polymaker PETG Galaxy @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13670,7 +13942,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG Galaxy/BBL/H2C/BambuStudio/Polymaker PETG Galaxy @BBL H2C.json",
       "filename": "Polymaker PETG Galaxy @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13689,7 +13961,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG Galaxy/BBL/H2D/BambuStudio/Polymaker PETG Galaxy @BBL H2D.json",
       "filename": "Polymaker PETG Galaxy @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13708,7 +13980,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG Galaxy/BBL/H2S/BambuStudio/Polymaker PETG Galaxy @BBL H2S.json",
       "filename": "Polymaker PETG Galaxy @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13727,7 +13999,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG Galaxy/BBL/P1S/BambuStudio/Polymaker PETG Galaxy @BBL P1S.json",
       "filename": "Polymaker PETG Galaxy @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13758,7 +14030,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG Galaxy/BBL/P2S/BambuStudio/Polymaker PETG Galaxy @BBL P2S.json",
       "filename": "Polymaker PETG Galaxy @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13777,7 +14049,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PETG Galaxy/BBL/X2D/BambuStudio/Polymaker PETG Galaxy @BBL X2D.json",
       "filename": "Polymaker PETG Galaxy @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13840,7 +14112,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA/BBL/A2L/BambuStudio/Polymaker PLA @BBL A2L.json",
       "filename": "Polymaker PLA @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13856,7 +14128,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA/BBL/H2C/BambuStudio/Polymaker PLA @BBL H2C.json",
       "filename": "Polymaker PLA @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13872,7 +14144,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA/BBL/H2D/BambuStudio/Polymaker PLA @BBL H2D.json",
       "filename": "Polymaker PLA @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13888,7 +14160,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA/BBL/H2S/BambuStudio/Polymaker PLA @BBL H2S.json",
       "filename": "Polymaker PLA @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13904,7 +14176,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA/BBL/P1S/BambuStudio/Polymaker PLA @BBL P1S.json",
       "filename": "Polymaker PLA @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13935,7 +14207,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA/BBL/P2S/BambuStudio/Polymaker PLA @BBL P2S.json",
       "filename": "Polymaker PLA @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -13951,7 +14223,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA/BBL/X2D/BambuStudio/Polymaker PLA @BBL X2D.json",
       "filename": "Polymaker PLA @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14025,7 +14297,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro/BBL/A1/BambuStudio/Polymaker PLA Pro @BBL A1.json",
       "filename": "Polymaker PLA Pro @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14046,7 +14318,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro/BBL/A2L/BambuStudio/Polymaker PLA Pro @BBL A2L.json",
       "filename": "Polymaker PLA Pro @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14062,7 +14334,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro/BBL/H2C/BambuStudio/Polymaker PLA Pro @BBL H2C.json",
       "filename": "Polymaker PLA Pro @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14078,7 +14350,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro/BBL/H2D/BambuStudio/Polymaker PLA Pro @BBL H2D.json",
       "filename": "Polymaker PLA Pro @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14094,7 +14366,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro/BBL/H2S/BambuStudio/Polymaker PLA Pro @BBL H2S.json",
       "filename": "Polymaker PLA Pro @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14110,7 +14382,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro/BBL/P1S/BambuStudio/Polymaker PLA Pro @BBL P1S.json",
       "filename": "Polymaker PLA Pro @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14141,7 +14413,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro/BBL/P2S/BambuStudio/Polymaker PLA Pro @BBL P2S.json",
       "filename": "Polymaker PLA Pro @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14157,7 +14429,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro/BBL/X2D/BambuStudio/Polymaker PLA Pro @BBL X2D.json",
       "filename": "Polymaker PLA Pro @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14236,7 +14508,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro Metallic/BBL/A1/BambuStudio/Polymaker PLA Pro Metallic @BBL A1.json",
       "filename": "Polymaker PLA Pro Metallic @BBL A1.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14257,7 +14529,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro Metallic/BBL/A2L/BambuStudio/Polymaker PLA Pro Metallic @BBL A2L.json",
       "filename": "Polymaker PLA Pro Metallic @BBL A2L.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14273,7 +14545,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro Metallic/BBL/H2C/BambuStudio/Polymaker PLA Pro Metallic @BBL H2C.json",
       "filename": "Polymaker PLA Pro Metallic @BBL H2C.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14289,7 +14561,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro Metallic/BBL/H2D/BambuStudio/Polymaker PLA Pro Metallic @BBL H2D.json",
       "filename": "Polymaker PLA Pro Metallic @BBL H2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14305,7 +14577,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro Metallic/BBL/H2S/BambuStudio/Polymaker PLA Pro Metallic @BBL H2S.json",
       "filename": "Polymaker PLA Pro Metallic @BBL H2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14321,7 +14593,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro Metallic/BBL/P1S/BambuStudio/Polymaker PLA Pro Metallic @BBL P1S.json",
       "filename": "Polymaker PLA Pro Metallic @BBL P1S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14352,7 +14624,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro Metallic/BBL/P2S/BambuStudio/Polymaker PLA Pro Metallic @BBL P2S.json",
       "filename": "Polymaker PLA Pro Metallic @BBL P2S.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",
@@ -14368,7 +14640,7 @@
       "slicer": "BambuStudio",
       "path": "preset/Polymaker PLA Pro Metallic/BBL/X2D/BambuStudio/Polymaker PLA Pro Metallic @BBL X2D.json",
       "filename": "Polymaker PLA Pro Metallic @BBL X2D.json",
-      "updatedAt": "2026-08-14T13:53:57+08:00",
+      "updatedAt": "2026-08-14T15:28:59+08:00",
       "compatiblePrinters": [
         {
           "brand": "BBL",

--- a/preset/Fiberon PET-CF17/BBL/H2S/BambuStudio/Fiberon PET-CF17 @BBL H2S.json
+++ b/preset/Fiberon PET-CF17/BBL/H2S/BambuStudio/Fiberon PET-CF17 @BBL H2S.json
@@ -286,11 +286,11 @@
         "0"
     ],
     "nozzle_temperature": [
-        "70",
+        "300",
         "nil"
     ],
     "nozzle_temperature_initial_layer": [
-        "70",
+        "300",
         "nil"
     ],
     "nozzle_temperature_range_high": [
@@ -371,7 +371,7 @@
     "include": [
         "fdm_filament_template_direct_dual"
     ],
-    "version": "2.6.0.5",
+    "version": "2.6.0.2",
     "idle_temperature": [
         "0"
     ],

--- a/preset/Panchroma PLA Celestial/Creality/I7/CrealityPrint/Panchroma PLA Celestial @Creality I7.json
+++ b/preset/Panchroma PLA Celestial/Creality/I7/CrealityPrint/Panchroma PLA Celestial @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "Panchroma PLA Celestial @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "Panchroma PLA Celestial @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL02",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/Panchroma PLA Galaxy/Creality/I7/CrealityPrint/Panchroma PLA Galaxy @Creality I7.json
+++ b/preset/Panchroma PLA Galaxy/Creality/I7/CrealityPrint/Panchroma PLA Galaxy @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "Panchroma PLA Galaxy @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "Panchroma PLA Galaxy @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL03",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/Panchroma PLA Glow/Creality/I7/CrealityPrint/Panchroma PLA Glow @Creality I7.json
+++ b/preset/Panchroma PLA Glow/Creality/I7/CrealityPrint/Panchroma PLA Glow @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "Panchroma PLA Glow @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "Panchroma PLA Glow @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL04",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/Panchroma PLA Luminous/Creality/I7/CrealityPrint/Panchroma PLA Luminous @Creality I7.json
+++ b/preset/Panchroma PLA Luminous/Creality/I7/CrealityPrint/Panchroma PLA Luminous @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "Panchroma PLA Luminous @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "Panchroma PLA Luminous @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL05",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/Panchroma PLA Metallic/Creality/I7/CrealityPrint/Panchroma PLA Metallic @Creality I7.json
+++ b/preset/Panchroma PLA Metallic/Creality/I7/CrealityPrint/Panchroma PLA Metallic @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "Panchroma PLA Metallic @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "Panchroma PLA Metallic @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL08",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/Panchroma PLA Neon/Creality/I7/CrealityPrint/Panchroma PLA Neon @Creality I7.json
+++ b/preset/Panchroma PLA Neon/Creality/I7/CrealityPrint/Panchroma PLA Neon @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "Panchroma PLA Neon @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "Panchroma PLA Neon @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL09",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/Panchroma PLA Starlight/Creality/I7/CrealityPrint/Panchroma PLA Starlight @Creality I7.json
+++ b/preset/Panchroma PLA Starlight/Creality/I7/CrealityPrint/Panchroma PLA Starlight @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "Panchroma PLA Starlight @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "Panchroma PLA Starlight @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL12",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/Panchroma PLA UV Shift/Creality/I7/CrealityPrint/Panchroma PLA UV Shift @Creality I7.json
+++ b/preset/Panchroma PLA UV Shift/Creality/I7/CrealityPrint/Panchroma PLA UV Shift @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "Panchroma PLA UV Shift @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "Panchroma PLA UV Shift @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL14",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/PolyLite PC/BBL/H2D/BambuStudio/PolyLite PC @BBL H2D.json
+++ b/preset/PolyLite PC/BBL/H2D/BambuStudio/PolyLite PC @BBL H2D.json
@@ -372,5 +372,8 @@
     "version": "2.7.0.9",
     "idle_temperature": [
         "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0"
     ]
 }

--- a/preset/PolyLite PLA Galaxy/Creality/I7/CrealityPrint/PolyLite PLA Galaxy @Creality I7.json
+++ b/preset/PolyLite PLA Galaxy/Creality/I7/CrealityPrint/PolyLite PLA Galaxy @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "PolyLite PLA Galaxy @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "PolyLite PLA Galaxy @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL16",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/PolyLite PLA Glow/Creality/I7/CrealityPrint/PolyLite PLA Glow @Creality I7.json
+++ b/preset/PolyLite PLA Glow/Creality/I7/CrealityPrint/PolyLite PLA Glow @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "PolyLite PLA Glow @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "PolyLite PLA Glow @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL17",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/PolyLite PLA Luminous/Creality/I7/CrealityPrint/PolyLite PLA Luminous @Creality I7.json
+++ b/preset/PolyLite PLA Luminous/Creality/I7/CrealityPrint/PolyLite PLA Luminous @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "PolyLite PLA Luminous @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "PolyLite PLA Luminous @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL18",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/PolyLite PLA Neon/Creality/I7/CrealityPrint/PolyLite PLA Neon @Creality I7.json
+++ b/preset/PolyLite PLA Neon/Creality/I7/CrealityPrint/PolyLite PLA Neon @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "PolyLite PLA Neon @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "PolyLite PLA Neon @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL19",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/PolyLite PLA Starlight/Creality/I7/CrealityPrint/PolyLite PLA Starlight @Creality I7.json
+++ b/preset/PolyLite PLA Starlight/Creality/I7/CrealityPrint/PolyLite PLA Starlight @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "PolyLite PLA Starlight @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "PolyLite PLA Starlight @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL22",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/PolyLite PLA Translucent/Creality/I7/CrealityPrint/PolyLite PLA Translucent @Creality I7.json
+++ b/preset/PolyLite PLA Translucent/Creality/I7/CrealityPrint/PolyLite PLA Translucent @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "PolyLite PLA Translucent @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "PolyLite PLA Translucent @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL23",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/PolyLite PLA/Creality/I7/CrealityPrint/PolyLite PLA @Creality I7.json
+++ b/preset/PolyLite PLA/Creality/I7/CrealityPrint/PolyLite PLA @Creality I7.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Panchroma PLA Translucent @Creality I7",
+    "name": "PolyLite PLA @Creality I7",
     "from": "User",
     "instantiation": "true",
     "cool_plate_temp": "55",
@@ -35,7 +35,7 @@
     "filament_retraction_minimum_travel": "2",
     "filament_retract_before_wipe": "100%",
     "filament_settings_id": [
-        "Panchroma PLA Translucent @Creality I7"
+        "PolyLite PLA @Creality I7"
     ],
     "filament_soluble": [
         "0"
@@ -79,7 +79,7 @@
         "230"
     ],
     "additional_cooling_fan_speed": "0",
-    "filament_id": "PMPL13",
+    "filament_id": "PMPL15",
     "setting_id": "GFSA04",
     "activate_air_filtration": "0",
     "activate_chamber_temp_control": "0",

--- a/preset/PolyMax PC/BBL/H2D/BambuStudio/PolyMax PC @BBL H2D.json
+++ b/preset/PolyMax PC/BBL/H2D/BambuStudio/PolyMax PC @BBL H2D.json
@@ -372,5 +372,8 @@
     "version": "2.7.0.9",
     "idle_temperature": [
         "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0"
     ]
 }

--- a/preset/PolyMax PC/BBL/H2S/BambuStudio/PolyMax PC @BBL H2S.json
+++ b/preset/PolyMax PC/BBL/H2S/BambuStudio/PolyMax PC @BBL H2S.json
@@ -390,5 +390,8 @@
     "version": "2.7.0.9",
     "idle_temperature": [
         "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0"
     ]
 }

--- a/preset/Polylite ASA for TYC Americas/BBL/H2C/BambuStudio/Polylite ASA for TYC Americas @BBL H2C.json
+++ b/preset/Polylite ASA for TYC Americas/BBL/H2C/BambuStudio/Polylite ASA for TYC Americas @BBL H2C.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "PolyLite ABS @BBL H2D",
+    "name": "Polylite ASA for TYC Americas @BBL H2C",
     "from": "User",
     "instantiation": "true",
     "activate_air_filtration": [
@@ -52,10 +52,10 @@
         "70"
     ],
     "eng_plate_temp": [
-        "90"
+        "100"
     ],
     "eng_plate_temp_initial_layer": [
-        "90"
+        "100"
     ],
     "fan_cooling_layer_time": [
         "30"
@@ -64,7 +64,7 @@
         "70"
     ],
     "fan_min_speed": [
-        "50"
+        "40"
     ],
     "filament_adaptive_volumetric_speed": [
         "0"
@@ -77,7 +77,8 @@
         "10"
     ],
     "filament_preheat_temperature_delta": [
-        "0"
+        "20",
+        "20"
     ],
     "filament_tower_interface_pre_extrusion_dist": [
         "10"
@@ -98,19 +99,19 @@
         "20"
     ],
     "filament_density": [
-        "1.12"
+        "1.13"
     ],
     "filament_dev_ams_drying_ams_limitations": [
         "1"
     ],
     "filament_dev_ams_drying_heat_distortion_temperature": [
-        "90"
+        "100"
     ],
     "filament_dev_ams_drying_temperature": [
         "65",
         "80",
         "65",
-        "75"
+        "80"
     ],
     "filament_dev_ams_drying_time": [
         "12",
@@ -125,20 +126,22 @@
         "12.0"
     ],
     "filament_dev_drying_cooling_temperature": [
-        "75"
+        "85"
     ],
     "filament_dev_drying_softening_temperature": [
-        "80"
+        "85"
     ],
     "filament_diameter": [
         "1.75"
     ],
     "filament_extruder_variant": [
         "Direct Drive Standard",
-        "Direct Drive High Flow"
+        "Direct Drive High Flow",
+        "Direct Drive E3D High Flow"
     ],
     "filament_flow_ratio": [
         "1.01",
+        "nil",
         "nil"
     ],
     "filament_flush_temp": [
@@ -152,6 +155,7 @@
     ],
     "filament_max_volumetric_speed": [
         "4",
+        "nil",
         "nil"
     ],
     "filament_metal_stickiness": [
@@ -164,19 +168,21 @@
         "0"
     ],
     "filament_pre_cooling_temperature_nc": [
-        "0"
+        "220",
+        "220"
     ],
     "filament_prime_volume": [
-        "45"
+        "30"
     ],
     "filament_prime_volume_nc": [
-        "60"
+        "30"
     ],
     "filament_printable": [
         "3"
     ],
     "filament_ramming_travel_time_nc": [
-        "0"
+        "1",
+        "1"
     ],
     "filament_ramming_volumetric_speed": [
         "-1"
@@ -184,11 +190,15 @@
     "filament_ramming_volumetric_speed_nc": [
         "-1"
     ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
     "filament_scarf_seam_type": [
         "none"
     ],
     "filament_settings_id": [
-        "PolyLite ABS @BBL H2D"
+        "Polylite ASA for TYC Americas @BBL H2C"
     ],
     "filament_shrink": [
         "100%"
@@ -197,10 +207,22 @@
         "0"
     ],
     "filament_type": [
-        "ABS"
+        "ASA"
     ],
     "filament_vendor": [
         "Polymaker"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
     ],
     "full_fan_speed_layer": [
         "0"
@@ -246,16 +268,16 @@
         "25"
     ],
     "filament_change_length": [
-        "10"
+        "4"
     ],
     "filament_velocity_adaptation_factor": [
         "1"
     ],
     "hot_plate_temp": [
-        "90"
+        "100"
     ],
     "hot_plate_temp_initial_layer": [
-        "90"
+        "100"
     ],
     "filament_ingredients_safe": "1",
     "filament_emission_safe": "1",
@@ -276,7 +298,7 @@
         "0.088"
     ],
     "impact_strength_z": [
-        "10"
+        "4.9"
     ],
     "long_retractions_when_ec": [
         "0"
@@ -285,18 +307,18 @@
         "0"
     ],
     "nozzle_temperature": [
-        "265",
-        "265"
+        "260",
+        "260"
     ],
     "nozzle_temperature_initial_layer": [
-        "265",
-        "265"
+        "260",
+        "260"
     ],
     "nozzle_temperature_range_high": [
-        "265"
+        "260"
     ],
     "nozzle_temperature_range_low": [
-        "245"
+        "230"
     ],
     "overhang_fan_speed": [
         "80"
@@ -339,7 +361,7 @@
         "0"
     ],
     "temperature_vitrification": [
-        "104"
+        "105"
     ],
     "textured_plate_temp": [
         "100"
@@ -351,7 +373,7 @@
         "0 0 0 0 0 0"
     ],
     "compatible_printers": [
-        "Bambu Lab H2D 0.4 nozzle"
+        "Bambu Lab H2C 0.4 nozzle"
     ],
     "filament_start_gcode": [
         "; filament start gcode\n"
@@ -359,17 +381,23 @@
     "filament_end_gcode": [
         "; filament end gcode \n"
     ],
-    "inherits": "Generic ABS @BBL H2D",
+    "inherits": "Generic ASA @BBL H2C 0.4 nozzle",
     "filament_adhesiveness_category": [
         "200"
     ],
-    "filament_id": "PMAB01",
+    "filament_id": "PMAS04",
     "description": " ",
-    "setting_id": "GFSB99_07",
+    "setting_id": "GFSB98_17",
+    "first_x_layer_fan_speed": [
+        "0"
+    ],
+    "filament_change_length_nc": [
+        "4"
+    ],
     "include": [
         "fdm_filament_template_direct_dual"
     ],
-    "version": "2.7.0.9",
+    "version": "2.8.0.4",
     "idle_temperature": [
         "0"
     ],

--- a/preset/Polylite ASA for TYC Americas/BBL/H2D/BambuStudio/Polylite ASA for TYC Americas @BBL H2D.json
+++ b/preset/Polylite ASA for TYC Americas/BBL/H2D/BambuStudio/Polylite ASA for TYC Americas @BBL H2D.json
@@ -372,5 +372,8 @@
     "version": "2.5.0.14",
     "idle_temperature": [
         "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0"
     ]
 }

--- a/preset/Polylite ASA for TYC Americas/BBL/H2S/BambuStudio/Polylite ASA for TYC Americas @BBL H2S.json
+++ b/preset/Polylite ASA for TYC Americas/BBL/H2S/BambuStudio/Polylite ASA for TYC Americas @BBL H2S.json
@@ -390,5 +390,8 @@
     "version": "2.7.0.9",
     "idle_temperature": [
         "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0"
     ]
 }

--- a/preset/Polylite ASA for TYC Americas/BBL/P2S/BambuStudio/Polylite ASA for TYC Americas @BBL P2S.json
+++ b/preset/Polylite ASA for TYC Americas/BBL/P2S/BambuStudio/Polylite ASA for TYC Americas @BBL P2S.json
@@ -394,5 +394,8 @@
     "version": "2.6.0.2",
     "idle_temperature": [
         "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0"
     ]
 }

--- a/preset/Polylite ASA for TYC Americas/BBL/X2D/BambuStudio/Polylite ASA for TYC Americas @BBL X2D.json
+++ b/preset/Polylite ASA for TYC Americas/BBL/X2D/BambuStudio/Polylite ASA for TYC Americas @BBL X2D.json
@@ -391,5 +391,8 @@
     "version": "2.7.0.9",
     "idle_temperature": [
         "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "0"
     ]
 }

--- a/preset/Polymaker ASA/BBL/H2C/BambuStudio/Polymaker ASA @BBL H2C.json
+++ b/preset/Polymaker ASA/BBL/H2C/BambuStudio/Polymaker ASA @BBL H2C.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "PolyLite ABS @BBL H2D",
+    "name": "Polymaker ASA @BBL H2C",
     "from": "User",
     "instantiation": "true",
     "activate_air_filtration": [
@@ -52,10 +52,10 @@
         "70"
     ],
     "eng_plate_temp": [
-        "90"
+        "100"
     ],
     "eng_plate_temp_initial_layer": [
-        "90"
+        "100"
     ],
     "fan_cooling_layer_time": [
         "30"
@@ -64,7 +64,7 @@
         "70"
     ],
     "fan_min_speed": [
-        "50"
+        "40"
     ],
     "filament_adaptive_volumetric_speed": [
         "0"
@@ -77,7 +77,8 @@
         "10"
     ],
     "filament_preheat_temperature_delta": [
-        "0"
+        "20",
+        "20"
     ],
     "filament_tower_interface_pre_extrusion_dist": [
         "10"
@@ -98,19 +99,19 @@
         "20"
     ],
     "filament_density": [
-        "1.12"
+        "1.13"
     ],
     "filament_dev_ams_drying_ams_limitations": [
         "1"
     ],
     "filament_dev_ams_drying_heat_distortion_temperature": [
-        "90"
+        "100"
     ],
     "filament_dev_ams_drying_temperature": [
         "65",
         "80",
         "65",
-        "75"
+        "80"
     ],
     "filament_dev_ams_drying_time": [
         "12",
@@ -125,20 +126,22 @@
         "12.0"
     ],
     "filament_dev_drying_cooling_temperature": [
-        "75"
+        "85"
     ],
     "filament_dev_drying_softening_temperature": [
-        "80"
+        "85"
     ],
     "filament_diameter": [
         "1.75"
     ],
     "filament_extruder_variant": [
         "Direct Drive Standard",
-        "Direct Drive High Flow"
+        "Direct Drive High Flow",
+        "Direct Drive E3D High Flow"
     ],
     "filament_flow_ratio": [
         "1.01",
+        "nil",
         "nil"
     ],
     "filament_flush_temp": [
@@ -152,6 +155,7 @@
     ],
     "filament_max_volumetric_speed": [
         "4",
+        "nil",
         "nil"
     ],
     "filament_metal_stickiness": [
@@ -164,19 +168,21 @@
         "0"
     ],
     "filament_pre_cooling_temperature_nc": [
-        "0"
+        "220",
+        "220"
     ],
     "filament_prime_volume": [
-        "45"
+        "30"
     ],
     "filament_prime_volume_nc": [
-        "60"
+        "30"
     ],
     "filament_printable": [
         "3"
     ],
     "filament_ramming_travel_time_nc": [
-        "0"
+        "1",
+        "1"
     ],
     "filament_ramming_volumetric_speed": [
         "-1"
@@ -184,11 +190,15 @@
     "filament_ramming_volumetric_speed_nc": [
         "-1"
     ],
+    "filament_retraction_length": [
+        "0.4",
+        "0.4"
+    ],
     "filament_scarf_seam_type": [
         "none"
     ],
     "filament_settings_id": [
-        "PolyLite ABS @BBL H2D"
+        "Polymaker ASA @BBL H2C"
     ],
     "filament_shrink": [
         "100%"
@@ -197,10 +207,22 @@
         "0"
     ],
     "filament_type": [
-        "ABS"
+        "ASA"
     ],
     "filament_vendor": [
         "Polymaker"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
     ],
     "full_fan_speed_layer": [
         "0"
@@ -246,16 +268,16 @@
         "25"
     ],
     "filament_change_length": [
-        "10"
+        "4"
     ],
     "filament_velocity_adaptation_factor": [
         "1"
     ],
     "hot_plate_temp": [
-        "90"
+        "100"
     ],
     "hot_plate_temp_initial_layer": [
-        "90"
+        "100"
     ],
     "filament_ingredients_safe": "1",
     "filament_emission_safe": "1",
@@ -276,7 +298,7 @@
         "0.088"
     ],
     "impact_strength_z": [
-        "10"
+        "4.9"
     ],
     "long_retractions_when_ec": [
         "0"
@@ -285,18 +307,18 @@
         "0"
     ],
     "nozzle_temperature": [
-        "265",
-        "265"
+        "260",
+        "260"
     ],
     "nozzle_temperature_initial_layer": [
-        "265",
-        "265"
+        "260",
+        "260"
     ],
     "nozzle_temperature_range_high": [
-        "265"
+        "260"
     ],
     "nozzle_temperature_range_low": [
-        "245"
+        "230"
     ],
     "overhang_fan_speed": [
         "80"
@@ -339,7 +361,7 @@
         "0"
     ],
     "temperature_vitrification": [
-        "104"
+        "105"
     ],
     "textured_plate_temp": [
         "100"
@@ -351,7 +373,7 @@
         "0 0 0 0 0 0"
     ],
     "compatible_printers": [
-        "Bambu Lab H2D 0.4 nozzle"
+        "Bambu Lab H2C 0.4 nozzle"
     ],
     "filament_start_gcode": [
         "; filament start gcode\n"
@@ -359,17 +381,23 @@
     "filament_end_gcode": [
         "; filament end gcode \n"
     ],
-    "inherits": "Generic ABS @BBL H2D",
+    "inherits": "Generic ASA @BBL H2C 0.4 nozzle",
     "filament_adhesiveness_category": [
         "200"
     ],
-    "filament_id": "PMAB01",
+    "filament_id": "PMAS02",
     "description": " ",
-    "setting_id": "GFSB99_07",
+    "setting_id": "GFSB98_17",
+    "first_x_layer_fan_speed": [
+        "0"
+    ],
+    "filament_change_length_nc": [
+        "4"
+    ],
     "include": [
         "fdm_filament_template_direct_dual"
     ],
-    "version": "2.7.0.9",
+    "version": "2.8.0.4",
     "idle_temperature": [
         "0"
     ],


### PR DESCRIPTION
Key updates include adding Panchroma and PolyLite material presets for the Creality I7 platform, as well as ASA presets for the BBL H2C platform; adjusting the printing temperature, flow ratio, maximum volumetric speed, pressure advance, and cooling parameters for `Panchroma PLA Translucent @ Creality I7`; correcting the nozzle temperature and configuration version for `Fiberon PET-CF17 @ BBL H2S`; and adding the `filament_long_retractions_when_cut` parameter to selected BambuStudio H2D/H2S/P2S/X2D presets to further improve preset compatibility and printing performance.