### PR TITLE
Add optional PostHog build analytics

### DIFF
--- a/.github/workflows/auto-update-index-json.yml
+++ b/.github/workflows/auto-update-index-json.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: '22.x'
 
       - name: Generate index.json
         run: node scripts/generate-index-json.mjs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: ['20.20.0', '22.22.0', '24.x']
     
     steps:
     - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     
     - name: Install dependencies
-      run: npm ci || npm install
+      run: npm ci
     
     - name: Run tests
       run: npm run test:all
@@ -44,7 +44,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '22.x'
     
     - name: Verify preset JSON files
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ doc-outside/
 .playwright-mcp/
 .ruff_cache/
 .claude/
+node_modules/
+.env
+.env.*
+!.env.example
+posthog-self-driving-report.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ node scripts/generate-index-json.mjs
 ```
 
 Requirements:
-- Node.js 18+
+- Node.js 20.20+ (20.x), or 22.22+ (recommended)
 
 ## CI/CD Workflow
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ npm run test:app
 
 ### Prerequisites
 
-- Node.js 18 or higher
+- Node.js 20.20+ (20.x), or 22.22+ (recommended)
 
 ### Local Development
 
@@ -253,6 +253,13 @@ npm run generate-index
 # or
 node scripts/generate-index-json.mjs
 ```
+
+Generation works without installing dependencies when `POSTHOG_API_KEY` is unset.
+For optional build analytics, run `npm ci` and provide `POSTHOG_API_KEY` through
+your shell or CI environment; `POSTHOG_HOST` optionally overrides the US endpoint.
+These scripts do not load `.env` automatically. Keep credentials out of tracked
+files and generated site content. This integration records build events, not
+website visitor activity.
 
 ## 🔗 Links
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,46 @@
       "name": "polymaker-preset",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "posthog-node": "^5.51.6"
+      },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.50.5",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.50.5.tgz",
+      "integrity": "sha512-afEchuShDaVIoxAIj76kDZQ1DhfesDmgfVp+mtTzsA3wlc8DF5uoz8YjuTjnxOicWkpP5HCDqYidK/1kT125Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.409.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.409.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.409.0.tgz",
+      "integrity": "sha512-239umoaZVb2GBaXeEyJpwFvjhrrChJH8NHCwiao23EBSu3NA6EN0MTMoaHSmMEf4yjiXEFFoYJA6FjJAXF5HGA==",
+      "license": "MIT"
+    },
+    "node_modules/posthog-node": {
+      "version": "5.51.6",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.51.6.tgz",
+      "integrity": "sha512-r+Ge3p0OnOcOWeTnvKZmAtDwECeIoyNTyxBxuZc8wM6RHCQ9j2Xrhogrf39HSq1Y2gIOpWLqIDRmWDcu7xmqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.50.0"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "posthog-node": "^5.51.6"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "^20.20.0 || >=22.22.0"
       }
     },
     "node_modules/@posthog/core": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Polymaker",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^20.20.0 || >=22.22.0"
   },
   "dependencies": {
     "posthog-node": "^5.51.6"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "license": "MIT",
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "posthog-node": "^5.51.6"
   }
 }

--- a/scripts/generate-index-json.mjs
+++ b/scripts/generate-index-json.mjs
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import { capture, captureException, shutdown } from './posthog.mjs';
 
 const REPO_ROOT = process.cwd();
 const PRESET_DIR = path.join(REPO_ROOT, 'preset');
@@ -232,6 +233,21 @@ async function main() {
   await fs.writeFile(INDEX_JSON_PATH, JSON.stringify(next, null, 2) + '\n', 'utf8');
   // eslint-disable-next-line no-console
   console.log(`Generated index.json with ${next.presets.length} presets.`);
+
+  capture('index_generated', {
+    preset_count: next.presets.length,
+    material_count: next.materials.length,
+    brand_count: next.brands.length,
+    model_count: next.models.length,
+    slicer_count: next.slicers.length,
+  });
 }
 
-await main();
+try {
+  await main();
+} catch (err) {
+  captureException(err);
+  throw err;
+} finally {
+  await shutdown();
+}

--- a/scripts/generate-seo.mjs
+++ b/scripts/generate-seo.mjs
@@ -14,6 +14,7 @@
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { capture, captureException, shutdown } from './posthog.mjs';
 
 const REPO_ROOT = process.cwd();
 const INDEX_JSON_PATH = path.join(REPO_ROOT, 'index.json');
@@ -308,15 +309,32 @@ async function main() {
   const next = injectSeo(html, data);
   if (next === html) {
     console.log('index.html SEO content unchanged.');
+    capture('seo_injected', {
+      preset_count: data.presets.length,
+      material_count: data.materials.length,
+      changed: false,
+    });
     return;
   }
   await fs.writeFile(INDEX_HTML_PATH, next, 'utf8');
   console.log(
     `Injected SEO content: ${data.presets.length} presets, ${data.materials.length} materials.`
   );
+  capture('seo_injected', {
+    preset_count: data.presets.length,
+    material_count: data.materials.length,
+    changed: true,
+  });
 }
 
 // Only run when executed directly (not when imported by tests).
 if (import.meta.url === `file://${process.argv[1]}`) {
-  await main();
+  try {
+    await main();
+  } catch (err) {
+    captureException(err);
+    throw err;
+  } finally {
+    await shutdown();
+  }
 }

--- a/scripts/posthog.mjs
+++ b/scripts/posthog.mjs
@@ -8,14 +8,14 @@
  * is never silently ignored.
  */
 
-import { PostHog } from 'posthog-node';
-
 const apiKey = process.env.POSTHOG_API_KEY;
 const host = process.env.POSTHOG_HOST;
 
 let posthog = null;
 
 if (apiKey) {
+  // Keep dependency-free generation working when analytics is disabled.
+  const { PostHog } = await import('posthog-node');
   posthog = new PostHog(apiKey, {
     host: host || 'https://us.i.posthog.com',
     // Build scripts are short-lived processes — flush immediately so no

--- a/scripts/posthog.mjs
+++ b/scripts/posthog.mjs
@@ -1,0 +1,70 @@
+/**
+ * Shared PostHog client for build scripts.
+ *
+ * The client is optional — if POSTHOG_API_KEY is not set the module exports
+ * a no-op so build scripts keep working without analytics configured.
+ *
+ * In non-production environments a loud warning is printed so the missing key
+ * is never silently ignored.
+ */
+
+import { PostHog } from 'posthog-node';
+
+const apiKey = process.env.POSTHOG_API_KEY;
+const host = process.env.POSTHOG_HOST;
+
+let posthog = null;
+
+if (apiKey) {
+  posthog = new PostHog(apiKey, {
+    host: host || 'https://us.i.posthog.com',
+    // Build scripts are short-lived processes — flush immediately so no
+    // events are dropped when the process exits.
+    flushAt: 1,
+    flushInterval: 0,
+    enableExceptionAutocapture: true,
+  });
+} else if (process.env.NODE_ENV !== 'production') {
+  console.warn(
+    'POSTHOG_API_KEY variable required by PostHog is missing or un-configured, ' +
+    'this causes events to be silently missed. ' +
+    'This error stops appearing once POSTHOG_API_KEY is configured.'
+  );
+}
+
+/**
+ * A stable distinct ID for CI / build-time events.
+ * Uses CI_COMMIT_AUTHOR, GIT_AUTHOR_NAME, or falls back to 'build-script'.
+ */
+export const buildDistinctId =
+  process.env.CI_COMMIT_AUTHOR ||
+  process.env.GIT_AUTHOR_NAME ||
+  process.env.USER ||
+  'build-script';
+
+/**
+ * Capture a build-time event. No-ops when PostHog is not configured.
+ * @param {string} event
+ * @param {Record<string, unknown>} [properties]
+ */
+export function capture(event, properties) {
+  if (!posthog) return;
+  posthog.capture({ distinctId: buildDistinctId, event, properties });
+}
+
+/**
+ * Capture an exception. No-ops when PostHog is not configured.
+ * @param {unknown} error
+ */
+export function captureException(error) {
+  if (!posthog) return;
+  posthog.captureException(error, buildDistinctId);
+}
+
+/**
+ * Flush all pending events and shut down. Call once before process exit.
+ */
+export async function shutdown() {
+  if (!posthog) return;
+  await posthog.shutdown();
+}

--- a/scripts/posthog.test.mjs
+++ b/scripts/posthog.test.mjs
@@ -1,0 +1,79 @@
+import { it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, copyFile, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+async function isolatedClient(t) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'polymaker-posthog-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  await copyFile(new URL('./posthog.mjs', import.meta.url), path.join(dir, 'posthog.mjs'));
+  return dir;
+}
+
+function run(dir, code, extraEnv = {}) {
+  return execFileSync(process.execPath, ['--input-type=module', '-e', code], {
+    cwd: dir,
+    encoding: 'utf8',
+    timeout: 10000,
+    env: {
+      ...process.env,
+      NODE_OPTIONS: '',
+      POSTHOG_API_KEY: '',
+      POSTHOG_HOST: '',
+      ...extraEnv,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+for (const mode of ['development', 'production']) {
+  it(`works without the SDK or a key in ${mode}`, async (t) => {
+    const dir = await isolatedClient(t);
+    const output = run(dir, `
+      const client = await import('./posthog.mjs');
+      client.capture('index_generated', { preset_count: 1 });
+      client.captureException(new Error('test error'));
+      await client.shutdown();
+      console.log('done');
+    `, { NODE_ENV: mode });
+    assert.equal(output.trim(), 'done');
+  });
+}
+
+it('loads the SDK and forwards events, exceptions and shutdown when configured', async (t) => {
+  const dir = await isolatedClient(t);
+  const sdkDir = path.join(dir, 'node_modules', 'posthog-node');
+  await mkdir(sdkDir, { recursive: true });
+  await writeFile(path.join(sdkDir, 'package.json'), JSON.stringify({
+    name: 'posthog-node', type: 'module', exports: './index.js',
+  }));
+  // A local SDK double exercises initialization without sending analytics.
+  await writeFile(path.join(sdkDir, 'index.js'), `
+    export class PostHog {
+      constructor(key, options) { console.log(JSON.stringify({ key, options })); }
+      capture(event) { console.log(JSON.stringify(event)); }
+      captureException(error, id) { console.log(JSON.stringify({ error: error.message, id })); }
+      async shutdown() { console.log(JSON.stringify('shutdown')); }
+    }
+  `);
+  const output = run(dir, `
+    const client = await import('./posthog.mjs');
+    client.capture('index_generated', { preset_count: 1 });
+    client.captureException(new Error('test error'));
+    await client.shutdown();
+  `, {
+    POSTHOG_API_KEY: 'test-only-key',
+    POSTHOG_HOST: 'https://example.invalid',
+    CI_COMMIT_AUTHOR: 'test-builder',
+  });
+  const [init, event, exception, shutdown] = output.trim().split('\n').map(JSON.parse);
+  assert.equal(init.key, 'test-only-key');
+  assert.equal(init.options.host, 'https://example.invalid');
+  assert.deepEqual(event, {
+    distinctId: 'test-builder', event: 'index_generated', properties: { preset_count: 1 },
+  });
+  assert.deepEqual(exception, { error: 'test error', id: 'test-builder' });
+  assert.equal(shutdown, 'shutdown');
+});


### PR DESCRIPTION
Adds optional PostHog analytics to the index and SEO generators, capturing build counts and errors when POSTHOG_API_KEY is configured. The client loads only when enabled, so existing dependency-free generator jobs continue to work. No visitor tracking or credentials are added to the published site.

Aligns package requirements and CI with the SDK-supported Node versions, adds regression tests for disabled and configured analytics, and documents setup. Local environment files, dependencies, and the analytics report are ignored.

Validation:
- 237 tests passed on Node 24 after rebasing onto current main.
- Both generators passed in an isolated checkout without node_modules or an API key before the rebase.
- Clean npm ci with strict engine validation passed on Node 24.
- git diff --check passed.
