### PR TITLE
Enable PostHog build events on main

### DIFF
--- a/.github/workflows/posthog-build-analytics.yml
+++ b/.github/workflows/posthog-build-analytics.yml
@@ -1,0 +1,40 @@
+name: PostHog build analytics
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  capture-build:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Generate presets and send build events
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          CI_COMMIT_AUTHOR: github-actions
+        run: |
+          if [ -z "$POSTHOG_API_KEY" ]; then
+            echo "::error::Set the POSTHOG_API_KEY repository secret before running build analytics."
+            exit 1
+          fi
+          npm run generate

--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ These scripts do not load `.env` automatically. Keep credentials out of tracked
 files and generated site content. This integration records build events, not
 website visitor activity.
 
+The **PostHog build analytics** GitHub Actions workflow runs after pushes to
+`main`, or manually from the Actions tab on `main`. Set the repository secret
+`POSTHOG_API_KEY` to your PostHog project token and the repository variable
+`POSTHOG_HOST` to your ingestion endpoint (for example, `https://us.i.posthog.com`).
+It installs dependencies and runs both generators, sending `index_generated`
+and `seo_injected` events under `github-actions`. Generated files stay in the
+temporary runner; this workflow does not commit changes or publish the site.
+Pull request tests and preset-update jobs continue to run without analytics.
+
 ## 🔗 Links
 
 - **Download Page**: [https://presets.polymaker.com](https://presets.polymaker.com) 


### PR DESCRIPTION
The merged PostHog client had no workflow supplying its project token, so all CI captures were disabled. Add a dedicated workflow on main pushes and manual runs that installs dependencies, reads the POSTHOG_API_KEY secret and POSTHOG_HOST variable, and runs the index and SEO generators.

Uses read-only repository permissions, disables persisted checkout credentials, and limits execution to main. Generated files remain on the runner. Existing pull request jobs remain analytics-free. Uses a stable github-actions identity for build events.

Validation: YAML parsed locally and git diff --check passed. Repository token and US ingestion host were configured through the GitHub settings UI. End-to-end event verification follows the first main-branch run.
