### PR TITLE
Ignore native frames in third-party exception filter

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -29,10 +29,17 @@
     posthog._i.push([token, config, 'posthog']);
   };
 
-  // Suppress only exceptions whose frames are all identifiable third-party code.
-  // Missing stacks and unfamiliar paths may be first-party failures: retain them.
+  // Suppress only exceptions with identifiable third-party code in every stack.
+  // Ignore native frames; retain missing/native-only stacks and unfamiliar paths.
   var OWN_HOST = String(window.location.hostname).toLowerCase();
   var URL_HOST = /^(?:https?:)?\/\/([^/?#]+)/i;
+
+  function isNativeFrame(frame) {
+    // Native calls such as Array.reduce have no script origin. Neither an
+    // anonymous filename nor in_app: false alone is enough to ignore a frame.
+    return frame && frame.filename === '<anonymous>' && frame.in_app === false &&
+      (!frame.source || frame.source === '<anonymous>');
+  }
 
   function isThirdPartyFrame(frame) {
     // filename is the raw SDK location; source can be a host-stripped path.
@@ -54,7 +61,9 @@
     if (!Array.isArray(list) || list.length === 0) return false;
     return list.every(function(entry) {
       var frames = entry && entry.stacktrace && entry.stacktrace.frames;
-      return Array.isArray(frames) && frames.length > 0 && frames.every(isThirdPartyFrame);
+      if (!Array.isArray(frames)) return false;
+      var scriptFrames = frames.filter(function(frame) { return !isNativeFrame(frame); });
+      return scriptFrames.length > 0 && scriptFrames.every(isThirdPartyFrame);
     });
   }
 

--- a/tests/analytics-third-party-filter.test.js
+++ b/tests/analytics-third-party-filter.test.js
@@ -2,8 +2,9 @@
  * Tests for the third-party exception filter in analytics.js.
  *
  * The filter is the before_send hook passed to PostHog. It keeps an exception
- * unless every frame is identifiable third-party code. Unknown origins and
- * missing stacks are retained so first-party failures remain visible.
+ * unless every non-native frame is identifiable third-party code, with at
+ * least one such frame per exception. Unknown origins and missing stacks are
+ * retained so first-party failures remain visible.
  *
  * The test runs the real analytics.js source in a stub browser, then reads the
  * before_send function that the snippet queued for the SDK.
@@ -81,6 +82,20 @@ describe('analytics.js before_send filter', () => {
     assert.strictEqual(beforeSend(event), null);
   });
 
+  it('drops the chunk 7130 failure with five Klaviyo frames and native Array.reduce', () => {
+    const beforeSend = loadBeforeSend();
+    const event = exceptionEvent([
+      { filename: 'https://static.klaviyo.com/onsite/js/runtime.js', in_app: true },
+      { source: '/onsite/js/runtime.js', in_app: true },
+      { source: '/onsite/js/runtime.js', in_app: true },
+      { filename: '<anonymous>', function: 'Array.reduce', in_app: false },
+      { source: '/onsite/js/runtime.js', in_app: true },
+      { source: '/onsite/js/runtime.js', in_app: true }
+    ]);
+    event.properties.$exception_list[0].value = 'Loading chunk 7130 failed after 3 retries.';
+    assert.strictEqual(beforeSend(event), null);
+  });
+
   it('retains frameless exceptions whose origin cannot be established', () => {
     const beforeSend = loadBeforeSend();
     for (const frames of [[], undefined]) {
@@ -122,6 +137,44 @@ describe('analytics.js before_send filter', () => {
 });
 
 describe('unknown-origin exception protection', () => {
+  const nativeFrame = { filename: '<anonymous>', function: 'Array.reduce', in_app: false };
+  const foreignFrame = { source: '/onsite/js/runtime.js', in_app: true };
+
+  it('retains native-only stacks, including native-only exception causes', () => {
+    const beforeSend = loadBeforeSend();
+    const event = exceptionEvent([nativeFrame]);
+    assert.strictEqual(beforeSend(event), event);
+    const cause = exceptionEvent([foreignFrame, nativeFrame]);
+    cause.properties.$exception_list.push({ stacktrace: { frames: [nativeFrame] } });
+    assert.strictEqual(beforeSend(cause), cause);
+  });
+
+  it('retains first-party or unknown code alongside vendor and native frames', () => {
+    const beforeSend = loadBeforeSend();
+    for (const frame of [
+      { filename: 'https://presets.polymaker.com/app.js', in_app: false },
+      { source: '/new-feature.js', in_app: false },
+      { filename: '<anonymous>', function: 'Array.reduce' },
+      { filename: '<anonymous>', function: 'Array.reduce', in_app: true },
+      { filename: '<anonymous>', in_app: 'false' },
+      { filename: '<anonymous>', source: '/app.js', in_app: false },
+      { function: 'Array.reduce', in_app: false },
+      null
+    ]) {
+      const event = exceptionEvent([foreignFrame, nativeFrame, frame]);
+      assert.strictEqual(beforeSend(event), event, JSON.stringify(frame));
+    }
+  });
+
+  it('checks every exception cause after ignoring native frames', () => {
+    const beforeSend = loadBeforeSend();
+    const event = exceptionEvent([foreignFrame, nativeFrame]);
+    event.properties.$exception_list.push({ stacktrace: { frames: [nativeFrame, foreignFrame] } });
+    assert.strictEqual(beforeSend(event), null);
+    event.properties.$exception_list[1].stacktrace.frames.push({ source: '/app.js' });
+    assert.strictEqual(beforeSend(event), event);
+  });
+
   it('retains unknown, inline, malformed, and newly added first-party frames', () => {
     const beforeSend = loadBeforeSend();
     for (const frame of [


### PR DESCRIPTION
The third-party exception filter retained Klaviyo chunk load errors when their stack included a native `Array.reduce` frame. Ignore frames with `filename: '<anonymous>'` and `in_app: false` when no conflicting source is present, so the reported five-vendor-frame plus one-native-frame stack is suppressed.

Each exception in the cause chain must still contain at least one identified third-party frame, and all remaining frames must be third party. First-party, unknown-origin, missing, and native-only stacks remain visible.

Validation: the chunk 7130 regression failed before the fix and passes afterward. Added coverage for native-only stacks, mixed first-party/unknown frames, and exception causes. `npm run test:all` passes all 277 tests; `node --check analytics.js` and `git diff --check` pass.
